### PR TITLE
monitoring: move prometheusSpec under prometheus where the chart reads it

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -175,8 +175,6 @@ spec:
           enabled: true
         datasources:
           enabled: true
-        kubeApiServer:
-      enabled: true
     kubeApiServer:
       enabled: true
     kubeControllerManager:

--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -223,19 +223,6 @@ spec:
         tls:
           - hosts:
               - "prometheus.${SECRET_DOMAIN}"
-    prometheusOperator:
-      prometheusConfigReloader:
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
-          limits:
-            cpu: 200m
-            memory: 100Mi
-      thanosService:
-        enabled: false
-      thanosServiceMonitor:
-        enabled: false
       prometheusSpec:
         ruleSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
@@ -259,5 +246,18 @@ spec:
           runAsNonRoot: true
           runAsUser: 2316
           fsGroup: 2316
+    prometheusOperator:
+      prometheusConfigReloader:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+          limits:
+            cpu: 200m
+            memory: 100Mi
+      thanosService:
+        enabled: false
+      thanosServiceMonitor:
+        enabled: false
       admissionWebhooks:
         timeoutSeconds: 30


### PR DESCRIPTION
## Problem

The `prometheusSpec:` block in the kube-prometheus-stack HelmRelease was nested under `prometheusOperator:` instead of `prometheus:`, so the chart has been silently ignoring every value in it:

- **`*SelectorNilUsesHelmValues: false`** never took effect → live Prometheus only ingests PodMonitors/ServiceMonitors/PrometheusRules labeled `release: kube-prometheus-stack`. Consequence: the CNPG database PodMonitors are not scraped at all (zero `cnpg_*` metrics exist), and the kured, metallb, and loki PrometheusRules are loaded by nothing.
- **`storageSpec`** never took effect → the StatefulSet has no volumeClaimTemplate and the TSDB runs on an `emptyDir` (verified on the live pod). The pre-created NFS-backed PVC from `config-pvc.yaml` is Bound but unmounted; all metric history is lost on every pod restart.
- `enableAdminAPI`, `walCompression`, and the securityContext were likewise inert.

## Fix

Pure relocation — the block moves under `prometheus:` verbatim, no values changed. `prometheusOperator:` keeps its real keys (config reloader resources, thanos toggles, admission webhook timeout).

## Expected effects on apply

- prometheus-operator recreates the StatefulSet with a volumeClaimTemplate whose name matches the existing Bound PVC, so the pod should adopt the NFS PV (`/tank/appdata/prometheus`, uid 2316 matches the securityContext). Brief monitoring blip during pod replacement; in-memory history is lost, which is true of any restart today.
- All PodMonitors/ServiceMonitors/Rules cluster-wide become eligible for ingestion: CNPG per-database metrics start flowing (prerequisite for the planned backup-staleness alert), and the kured/metallb/loki rules activate — some of those alerts may fire for the first time and need tuning.

## Verification plan post-merge

1. `kubectl get sts -n monitoring prometheus-kube-prometheus-stack-prometheus -o jsonpath='{.spec.volumeClaimTemplates[*].metadata.name}'` — non-empty
2. Pod volume `prometheus-...-db` backed by the PVC, not emptyDir
3. `cnpg_` metrics present in Prometheus; scrape pools include the four database PodMonitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)