### PR TITLE
monitoring: scrape shodan node + pve exporters

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -226,6 +226,30 @@ spec:
         serviceMonitorSelectorNilUsesHelmValues: false
         podMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
+        additionalScrapeConfigs:
+          # shodan (Proxmox host) — not part of the k3s cluster, so scraped
+          # via static config rather than ServiceMonitor. ${NFS_SERVER} is the
+          # shodan IP, substituted by Flux postBuild from cluster-secrets.
+          - job_name: node-shodan
+            static_configs:
+              - targets:
+                  - ${NFS_SERVER}:9100
+                labels:
+                  instance: shodan
+          # prometheus-pve-exporter multi-target: the exporter runs on shodan
+          # and talks to its local PVE API (target=localhost).
+          - job_name: pve-shodan
+            metrics_path: /pve
+            static_configs:
+              - targets:
+                  - localhost
+                labels:
+                  instance: shodan
+            relabel_configs:
+              - source_labels: [__address__]
+                target_label: __param_target
+              - target_label: __address__
+                replacement: ${NFS_SERVER}:9221
         #retention: 6h
         enableAdminAPI: true
         walCompression: true


### PR DESCRIPTION
## What

Adds two static `additionalScrapeConfigs` to the kube-prometheus-stack `prometheusSpec` so Prometheus scrapes the shodan Proxmox host. shodan isn't a k3s cluster member, so it can't be discovered via ServiceMonitor.

- **node-shodan** — node_exporter at `${NFS_SERVER}:9100` (`instance=shodan`)
- **pve-shodan** — prometheus-pve-exporter multi-target at `:9221`. The exporter runs on shodan and queries its local PVE API (`target=localhost`); relabeled so `instance=shodan` and the scrape hits `${NFS_SERVER}:9221/pve`.

The host address comes from the existing `${NFS_SERVER}` Flux postBuild substitution (cluster-secrets) rather than a hardcoded IP.

## Why

Brings Proxmox host + hypervisor metrics into the cluster Prometheus.

## Verification

Both exporters confirmed serving off-host before merge:
- `:9100/metrics` → 200, `node_zfs_*` present
- `:9221/pve?target=localhost` → 200, 1134 `pve_*` metrics

Exporter deploy (incl. the `PrivateTmp=true` crash fix) lives in the home_infra branch.

`kubectl kustomize` builds clean. After merge + Flux reconcile, will verify both targets show UP via the Prometheus targets API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)