### PR TITLE
cloudnative-pg: add backup-age + backup-failing alerts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
           TERRAFORM_TFLINT_CONFIG_FILE: .tflint.hcl
           YAML_CONFIG_FILE: .yamllint.yaml
           KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas -v 1.23.3
-          KUBERNETES_KUBECONFORM_OPTIONS: -skip HelmRelease,Kustomization
+          KUBERNETES_KUBECONFORM_OPTIONS: -skip HelmRelease,Kustomization,PrometheusRule
           # JSCPD: all detected clones are legitimate GitOps boilerplate (HelmRelease
           # spec blocks, SOPS metadata). Super-linter v7 overrides threshold to 0%
           # via CLI flags, making the .jscpdrc.json threshold setting ineffective.

--- a/cluster/apps/cloudnative-pg/cloudnative-pg/app/kustomization.yaml
+++ b/cluster/apps/cloudnative-pg/cloudnative-pg/app/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cloudnative-pg
 resources:
-  #- ./externalsecret.yaml
+  # - ./externalsecret.yaml
   - ./helm-release.yaml
   - ./plugin-barman-cloud.yaml
   - ./prometheus-rule.yaml

--- a/cluster/apps/cloudnative-pg/cloudnative-pg/app/kustomization.yaml
+++ b/cluster/apps/cloudnative-pg/cloudnative-pg/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   #- ./externalsecret.yaml
   - ./helm-release.yaml
   - ./plugin-barman-cloud.yaml
+  - ./prometheus-rule.yaml
 # configMapGenerator:
 #   - name: cloudnative-pg-dashboard
 #     files:

--- a/cluster/apps/cloudnative-pg/cloudnative-pg/app/prometheus-rule.yaml
+++ b/cluster/apps/cloudnative-pg/cloudnative-pg/app/prometheus-rule.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cloudnative-pg-backups
+spec:
+  groups:
+    - name: cnpg.backups
+      rules:
+        # Use the barman-cloud PLUGIN metrics. The legacy cnpg_collector_* /
+        # Cluster.status.lastSuccessfulBackup are deprecated and frozen at the
+        # in-core->plugin migration (CNPG #8902, plugin #380) — do NOT alert on
+        # them.
+        - alert: CNPGBackupTooOld
+          annotations:
+            summary: "CloudNativePG backup is stale in {{ $labels.namespace }}"
+            description: >-
+              No successful barman-cloud backup for the CloudNativePG cluster in
+              {{ $labels.namespace }} in {{ $value | humanizeDuration }}
+              (threshold 36h).
+          # all clusters back up daily; 36h leaves a ~12h grace window
+          expr: |
+            time() - max by (namespace) (barman_cloud_cloudnative_pg_io_last_available_backup_timestamp) > 129600
+          for: 30m
+          labels:
+            severity: critical
+        - alert: CNPGBackupFailing
+          annotations:
+            summary: "CloudNativePG backup failing in {{ $labels.namespace }}"
+            description: >-
+              The most recent barman-cloud backup attempt for the cluster in
+              {{ $labels.namespace }} failed more recently than the last
+              successful one.
+          expr: |
+            max by (namespace) (barman_cloud_cloudnative_pg_io_last_failed_backup_timestamp)
+              >
+            max by (namespace) (barman_cloud_cloudnative_pg_io_last_available_backup_timestamp)
+          for: 1h
+          labels:
+            severity: warning


### PR DESCRIPTION
## What

Adds a `PrometheusRule` (`cloudnative-pg-backups`) with two alerts:

- **CNPGBackupTooOld** (critical) — `time() - max by (namespace)(barman_cloud_cloudnative_pg_io_last_available_backup_timestamp) > 36h`
- **CNPGBackupFailing** (warning) — last failed backup timestamp newer than last successful

## Why

We had a CNPG backup freeze go unnoticed for ~3 months. The obvious metric to alert on — `cnpg_collector_last_available_backup_timestamp` / `Cluster.status.lastSuccessfulBackup` — is **deprecated and frozen** at the in-core→barman-cloud-plugin migration cutover and never updates (upstream [CNPG #8902](https://github.com/cloudnative-pg/cloudnative-pg/issues/8902), [plugin #380](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/380)), so an alert on it would never fire.

This rule uses the plugin-native `barman_cloud_cloudnative_pg_io_*` metrics, which are live and already scraped by the CNPG PodMonitor.

## Verification

Both expressions validated against live Prometheus:
- Both return **0 results** while healthy (no false positives)
- Current backup ages: authentik/freshrss fresh, immich 22h, mealie 23h — all under the 36h threshold (daily backups → ~12h grace)
- `kubectl kustomize` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)