### PR TITLE
opencloud: add isolated opencloud-test instance (v7.1.0)

### DIFF
--- a/cluster/apps/opencloud/kustomization.yaml
+++ b/cluster/apps/opencloud/kustomization.yaml
@@ -5,3 +5,5 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./opencloud/ks.yaml
+  - ./namespace-test.yaml
+  - ./opencloud-test/ks.yaml

--- a/cluster/apps/opencloud/namespace-test.yaml
+++ b/cluster/apps/opencloud/namespace-test.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opencloud-test

--- a/cluster/apps/opencloud/opencloud-test/app/config-pvc.yaml
+++ b/cluster/apps/opencloud/opencloud-test/app/config-pvc.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-opencloud-test-storage-users-pv
+  namespace: opencloud-test
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  mountOptions:
+    - nfsvers=4.2
+    - port=2049
+  nfs:
+    path: /tank/user_files/shared/opencloud-test
+    server: "${NFS_SERVER}"
+  persistentVolumeReclaimPolicy: Retain
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-opencloud-test-storage-users-pvc
+  namespace: opencloud-test
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  volumeName: nfs-opencloud-test-storage-users-pv
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-opencloud-test-data-pv
+  namespace: opencloud-test
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  mountOptions:
+    - nfsvers=4
+    - port=2049
+  nfs:
+    path: /tank/appdata/opencloud-test
+    server: "${NFS_SERVER}"
+  persistentVolumeReclaimPolicy: Retain
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-opencloud-test-data-pvc
+  namespace: opencloud-test
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  volumeName: nfs-opencloud-test-data-pv

--- a/cluster/apps/opencloud/opencloud-test/app/externalsecret.yaml
+++ b/cluster/apps/opencloud/opencloud-test/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kochhaus-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opencloud-test
+  namespace: opencloud-test
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password-connect
+  target:
+    name: opencloud-test-secret
+    template:
+      data:
+        idm-admin-password: "{{ .opencloud_admin_password }}"
+  dataFrom:
+    - extract:
+        key: opencloud
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "opencloud_$1"

--- a/cluster/apps/opencloud/opencloud-test/app/helm-release.yaml
+++ b/cluster/apps/opencloud/opencloud-test/app/helm-release.yaml
@@ -1,0 +1,116 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opencloud-test
+  namespace: opencloud-test
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      interval: 30m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+
+  values:
+    controllers:
+      opencloud-test:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsUser: 2316
+            runAsGroup: 2316
+            runAsNonRoot: true
+            fsGroup: 2316
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          opencloud:
+            image:
+              repository: opencloudeu/opencloud-rolling
+              tag: 7.1.0
+            command:
+              ["/bin/sh", "-c", "opencloud init || true; opencloud server"]
+            env:
+              IDM_CREATE_DEMO_USERS: false
+              IDM_ADMIN_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: opencloud-test-secret
+                    key: idm-admin-password
+              OC_ENABLE_OCM: false
+              OC_INSECURE: false
+              OC_LOG_LEVEL: debug
+              OC_URL: https://opencloud-test.${SECRET_DOMAIN}
+              PROXY_TLS: false
+              # System/metadata storage uses the decomposed driver — force messagepack
+              # so it never needs xattrs (matches prod). xattrs DO work on this NFS
+              # mount (verified 2026-06-13), so the storage-users posix driver default
+              # is left in place for an honest "does current OpenCloud run here" test.
+              OC_DECOMPOSEDFS_METADATA_BACKEND: messagepack
+              # --- tinker knob: uncomment to force the user-files store off posix/xattrs ---
+              # STORAGE_USERS_DRIVER: decomposed
+            envFrom:
+              - secretRef:
+                  name: opencloud-test-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+
+    service:
+      app:
+        controller: opencloud-test
+        ports:
+          http:
+            port: 9200
+
+    ingress:
+      app:
+        className: traefik
+        annotations:
+          hajimari.io/appName: "OpenCloud (test)"
+          hajimari.io/group: "Storage"
+          hajimari.io/icon: arcticons:owncloud
+        hosts:
+          - host: "opencloud-test.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+
+    persistence:
+      storage-users:
+        existingClaim: nfs-opencloud-test-storage-users-pvc
+        globalMounts:
+          - path: /var/lib/opencloud
+            subPath: data
+      data:
+        existingClaim: nfs-opencloud-test-data-pvc
+        globalMounts:
+          - path: /etc/opencloud
+            subPath: config
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+            subPath: tmp

--- a/cluster/apps/opencloud/opencloud-test/app/kustomization.yaml
+++ b/cluster/apps/opencloud/opencloud-test/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./config-pvc.yaml
+  - ./externalsecret.yaml
+  - ./helm-release.yaml

--- a/cluster/apps/opencloud/opencloud-test/ks.yaml
+++ b/cluster/apps/opencloud/opencloud-test/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-opencloud-test
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/opencloud/opencloud-test/app
+  dependsOn:
+    - name: cluster-apps-external-secrets-store-onepassword
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## What
Adds a fully isolated `opencloud-test` deployment to validate **OpenCloud v7.1.0** on our NFS/xattr storage setup **without touching the live v4.1.0 instance**.

## Why
Stuck on a grandfathered v4.1.0 (carried from oCIS v2/v3). The xattr-over-NFS blocker in the old notes is **resolved** — verified end-to-end 2026-06-13 (pod-written `user.*` xattr read back directly on shodan's ZFS). So the real question is whether a current release clean-inits here; this test instance answers that safely.

## Isolation
- Separate namespace `opencloud-test`, own Flux ks, own ingress host `opencloud-test.${SECRET_DOMAIN}`
- Dedicated NFS PVs/PVCs on `*-test` paths (same ZFS datasets as prod, zero overlap with prod data)
- Own ExternalSecret; prod HelmRelease/PVCs/data not referenced

## Experiment
- v7.1.0, clean `opencloud init` on an empty volume
- storage-users on default **posix** (honest test), `OC_LOG_LEVEL: debug` to catch any jetstream/NATS error
- system/metadata storage pinned to `messagepack`; commented `STORAGE_USERS_DRIVER: decomposed` knob

## Prereq (done)
Ansible test NFS dirs + exports for `/tank/{appdata,user_files/shared}/opencloud-test` provisioned on shodan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)