### PR TITLE
opencloud-test: fsGroupChangePolicy Always to fix clean-init perms

### DIFF
--- a/cluster/apps/opencloud/opencloud-test/app/helm-release.yaml
+++ b/cluster/apps/opencloud/opencloud-test/app/helm-release.yaml
@@ -28,7 +28,11 @@ spec:
             runAsGroup: 2316
             runAsNonRoot: true
             fsGroup: 2316
-            fsGroupChangePolicy: OnRootMismatch
+            # Always (not OnRootMismatch): the ansible-created volume root is already
+            # owned 2316, so OnRootMismatch skips the recursive chown and the
+            # kubelet-created subPath subdirs (config/data) stay root:root → uid 2316
+            # can't write its config on a clean init. Always forces the recurse.
+            fsGroupChangePolicy: Always
         containers:
           opencloud:
             image:


### PR DESCRIPTION
Fixes the CrashLoopBackOff on the fresh opencloud-test instance: kubelet skips the fsGroup recursive chown (OnRootMismatch + ansible-pre-owned volume root), leaving subPath config/data dirs root:root so uid 2316 can't write its config on clean init. `Always` forces the recurse. Isolated test instance only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)