### PR TITLE
opencloud: upgrade prod 4.1.0 -> 7.1.0

### DIFF
--- a/cluster/apps/opencloud/opencloud/app/helm-release.yaml
+++ b/cluster/apps/opencloud/opencloud/app/helm-release.yaml
@@ -23,6 +23,10 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         pod:
+          # Give NATS time to drain on SIGTERM before SIGKILL — ungraceful NATS
+          # shutdown is the documented cause of jetstream KV corruption
+          # (opencloud-eu#2282/#2314), the original v4->v5 failure trigger.
+          terminationGracePeriodSeconds: 120
           securityContext:
             runAsUser: 2316
             runAsGroup: 2316
@@ -33,7 +37,7 @@ spec:
           opencloud:
             image:
               repository: opencloudeu/opencloud-rolling
-              tag: 4.1.0
+              tag: 7.1.0
             command:
               ["/bin/sh", "-c", "opencloud init || true; opencloud server"]
             env:
@@ -70,6 +74,13 @@ spec:
               OC_LOG_LEVEL: info
               OC_URL: https://opencloud.${SECRET_DOMAIN}
               PROXY_TLS: false
+              # System/metadata (decomposed driver) uses messagepack so it never
+              # needs xattrs — matches the validated 7.1.0 test artifact.
+              OC_DECOMPOSEDFS_METADATA_BACKEND: messagepack
+              # Keep the NATS jetstream store OFF NFS (defaults to
+              # /var/lib/opencloud/nats on the NFS volume = corruption magnet).
+              # Non-authoritative cache/bus → local emptyDir is safe, self-heals.
+              NATS_NATS_STORE_DIR: /var/lib/nats-local
             envFrom:
               - secretRef:
                   name: opencloud-secret
@@ -129,3 +140,8 @@ spec:
         globalMounts:
           - path: /tmp
             subPath: tmp
+      # Local (non-NFS) home for the NATS jetstream store — see NATS_NATS_STORE_DIR.
+      nats-local:
+        type: emptyDir
+        globalMounts:
+          - path: /var/lib/nats-local


### PR DESCRIPTION
Promote the validated `opencloud-test` artifact to prod.

The test ran **7.1.0 clean on a copy of prod's real data for 12h** (PRs #1523-1526): OCS API serves `<status>ok</status>`, the v7 `import_space_members` migration completed, OIDC login verified (alex/nickie), no jetstream/xattr errors, no data loss.

## Changes (prod keeps subPath — its subdirs are pre-owned 2316)
- image `4.1.0` -> `7.1.0`
- `terminationGracePeriodSeconds: 120` (graceful NATS drain)
- NATS jetstream store off NFS (`NATS_NATS_STORE_DIR` + `nats-local` emptyDir)
- `OC_DECOMPOSEDFS_METADATA_BACKEND=messagepack` (no xattr dependency)

## Cutover (in progress)
1. ✅ ZFS snapshot prod (rollback backstop)
2. ✅ prod scaled to 0 + HR suspended (volume quiesced)
3. ✅ rsync migrated test data+config -> prod volumes (`-aHAX`, `--exclude nats`)
4. ⏳ merge this PR
5. ⏳ resume HR + reconcile -> prod comes up on 7.1.0
6. ⏳ verify login + files

Data is already v7-migrated and config already carries `sharing.service_account`, so prod comes straight up. Rollback = restore snapshot + revert image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)