### PR TITLE
vllm: 31b kv-cache fp8 -> fp8_e5m2 (Ampere)

### DIFF
--- a/cluster/apps/ai/vllm/app/helm-release.yaml
+++ b/cluster/apps/ai/vllm/app/helm-release.yaml
@@ -199,8 +199,10 @@ spec:
               - "gemma4"
               - "--gpu-memory-utilization"
               - "0.95"
+              # fp8_e5m2 (NOT plain fp8 = e4m3 "fp8e4nv", which Ampere/sm_86
+              # can't do — it only supports e5m2/e4b15). Halves KV memory.
               - "--kv-cache-dtype"
-              - "fp8"
+              - "fp8_e5m2"
               - "--download-dir"
               - "/data/huggingface"
               - "--limit-mm-per-prompt"


### PR DESCRIPTION
First boot crashed in inductor autotune: `type fp8e4nv not supported in this architecture`. Plain `--kv-cache-dtype fp8` = E4M3 (fp8e4nv), which the 3090 (sm_86) can't do — Ampere only supports E5M2. One-word fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)