### PR TITLE
ai: add LiteLLM gateway (config-only MVP)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,7 +34,7 @@ jobs:
           TERRAFORM_TFLINT_CONFIG_FILE: .tflint.hcl
           YAML_CONFIG_FILE: .yamllint.yaml
           KUBERNETES_KUBEVAL_OPTIONS: --ignore-missing-schemas -v 1.23.3
-          KUBERNETES_KUBECONFORM_OPTIONS: -skip HelmRelease,Kustomization,PrometheusRule
+          KUBERNETES_KUBECONFORM_OPTIONS: -skip HelmRelease,Kustomization,PrometheusRule,ExternalSecret
           # JSCPD: all detected clones are legitimate GitOps boilerplate (HelmRelease
           # spec blocks, SOPS metadata). Super-linter v7 overrides threshold to 0%
           # via CLI flags, making the .jscpdrc.json threshold setting ineffective.

--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -1,0 +1,41 @@
+---
+# LiteLLM proxy config — config-file-only mode (no DB).
+# Upgrade path to DB-backed (virtual keys, spend tracking, admin UI): stand up a
+# CloudNative-PG Cluster for litellm, add DATABASE_URL (from its secret) +
+# STORE_MODEL_IN_DB=true to the helm-release env, then keys/spend live in PG.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: ai
+data:
+  config.yaml: |
+    model_list:
+      # Stable alias — point downstream apps (vane, OpenClaw, voice agent…) at
+      # "local" and you never re-plumb on a model/engine swap; just change the
+      # api_base/model below. THIS is the whole reason LiteLLM goes in first.
+      - model_name: local
+        litellm_params:
+          model: openai/google/gemma-4-12B-it-qat-w4a16-ct
+          api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
+          api_key: sk-noauth   # vLLM serves without auth; placeholder is required
+      # Explicit name too, for when you want to pin the exact model.
+      - model_name: gemma-12b
+        litellm_params:
+          model: openai/google/gemma-4-12B-it-qat-w4a16-ct
+          api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
+          api_key: sk-noauth
+      # --- future backends: add paid/free providers here, gated by sensitivity
+      # tier. e.g. a cloud frontier model for hard/non-sensitive work:
+      # - model_name: cloud-hard
+      #   litellm_params:
+      #     model: anthropic/<model-id>          # see claude-api skill for IDs
+      #     api_key: os.environ/ANTHROPIC_API_KEY
+
+    litellm_settings:
+      drop_params: true          # tolerate params a backend doesn't support
+      # num_retries: 2
+      # fallbacks: [{"local": ["cloud-hard"]}]   # when local is down/gaming
+
+    general_settings:
+      master_key: os.environ/LITELLM_MASTER_KEY

--- a/cluster/apps/ai/litellm/app/externalsecret.yaml
+++ b/cluster/apps/ai/litellm/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# Pulls the LiteLLM proxy auth key(s) from 1Password.
+#
+# PREREQUISITE (manual, one-time): create a 1Password item named "litellm"
+# (in the vault the 1password-connect store reads) with field(s):
+#   - LITELLM_MASTER_KEY   e.g. sk-<random>   (the proxy admin/API key)
+#   - LITELLM_SALT_KEY     (optional; only needed once a DB stores provider keys)
+# dataFrom.extract maps each 1Password field -> a key in the k8s secret, which
+# the helm-release injects via envFrom. Without this item the pod won't start
+# (missing envFrom secret), so create it before/at merge time.
+# yaml-language-server: $schema=https://kochhaus-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-secret
+  namespace: ai
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password-connect
+  target:
+    name: litellm-secret
+  dataFrom:
+    - extract:
+        key: litellm

--- a/cluster/apps/ai/litellm/app/helm-release.yaml
+++ b/cluster/apps/ai/litellm/app/helm-release.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: litellm
+  namespace: ai
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      interval: 30m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+
+  values:
+    controllers:
+      litellm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          litellm:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: v1.89.1
+            args:
+              - "--config"
+              - "/etc/litellm/config.yaml"
+              - "--port"
+              - "4000"
+            envFrom:
+              - secretRef:
+                  name: litellm-secret
+            probes:
+              # TCP probes for the MVP — robust against a path typo on first boot.
+              # Upgrade to HTTP later: liveness /health/liveliness,
+              # readiness /health/readiness (LiteLLM's own endpoints).
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 4000
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 4000
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+    service:
+      app:
+        controller: litellm
+        ports:
+          http:
+            port: 4000
+
+    ingress:
+      app:
+        className: traefik
+        annotations:
+          hajimari.io/appName: "LiteLLM"
+          hajimari.io/group: "Gen-AI"
+          hajimari.io/icon: mdi:router-network
+        hosts:
+          - host: "litellm.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+
+    persistence:
+      config:
+        type: configMap
+        name: litellm-config
+        globalMounts:
+          - path: /etc/litellm
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/cluster/apps/ai/litellm/app/kustomization.yaml
+++ b/cluster/apps/ai/litellm/app/kustomization.yaml
@@ -3,6 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./vllm/ks.yaml
-  - ./litellm/ks.yaml
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helm-release.yaml

--- a/cluster/apps/ai/litellm/ks.yaml
+++ b/cluster/apps/ai/litellm/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-litellm
+  namespace: flux-system
+spec:
+  path: "./cluster/apps/ai/litellm/app"
+  dependsOn:
+    - name: cluster-apps-external-secrets-store-onepassword
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m


### PR DESCRIPTION
Foundation for the model-routing work: a stable OpenAI-compatible gateway in front of vLLM, so vane / OpenClaw / the voice agent point at **one fixed endpoint + alias** and a model/engine swap becomes a one-line edit here instead of re-plumbing downstream.

## What this is
- **bjw-s app-template** (matches the rest of the cluster), namespace `ai`
- **Config-file-only** (no DB) — the deliberate MVP; makes swaps trivial
- `model_list` → existing **`vllm-router-service`**; exposes a stable **`local`** alias + explicit `gemma-12b`
- Master key via **1Password ExternalSecret** (`ClusterSecretStore/1password-connect`)
- **traefik** ingress `litellm.${SECRET_DOMAIN}`
- Image pinned `ghcr.io/berriai/litellm:v1.89.1` (no floating tags)
- **TCP probes** for first-boot robustness (HTTP `/health/*` noted as an easy upgrade)

## ⚠️ One manual prerequisite before merge
Create a 1Password item **`litellm`** with field **`LITELLM_MASTER_KEY`** (e.g. `sk-<random>`). Without it the pod won't start (missing `envFrom` secret). Optional `LITELLM_SALT_KEY` only matters once a DB is added.

## Upgrade paths (documented in configmap, not done here)
- **DB-backed** (virtual keys, spend tracking, admin UI): a **CloudNative-PG** `Cluster` + `DATABASE_URL` + `STORE_MODEL_IN_DB=true`.
- **More backends**: add paid/free providers to `model_list`, gated by sensitivity tier; wire `fallbacks` so `local` fails over when the GPU's gaming.

## Not merged
Left for you to review + create the 1Password item, then merge & watch it come up. Test after: `curl -H "Authorization: Bearer $KEY" https://litellm.<domain>/v1/models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)