### PR TITLE
litellm: bump memory 1Gi -> 2Gi (OOMKilled on startup)

### DIFF
--- a/cluster/apps/ai/litellm/app/helm-release.yaml
+++ b/cluster/apps/ai/litellm/app/helm-release.yaml
@@ -62,9 +62,10 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 256Mi
+                memory: 512Mi
               limits:
-                memory: 1Gi
+                # LiteLLM spikes loading provider SDKs at startup; 1Gi OOMKilled it.
+                memory: 2Gi
 
     service:
       app:


### PR DESCRIPTION
LiteLLM OOMKilled crashlooping at 1Gi — it spikes loading provider SDKs on startup. Bump to 2Gi limit / 512Mi request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)