### PR TITLE
vane: self-hosted AI research engine (Perplexica 2.0)

### DIFF
--- a/cluster/apps/kustomization.yaml
+++ b/cluster/apps/kustomization.yaml
@@ -30,3 +30,4 @@ resources:
   - retrosavemanager
   - searxng
   - syncthing
+  - vane

--- a/cluster/apps/vane/kustomization.yaml
+++ b/cluster/apps/vane/kustomization.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./vane/ks.yaml

--- a/cluster/apps/vane/namespace.yaml
+++ b/cluster/apps/vane/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vane

--- a/cluster/apps/vane/vane/app/helm-release.yaml
+++ b/cluster/apps/vane/vane/app/helm-release.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vane
+  namespace: vane
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      interval: 30m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+
+  values:
+    controllers:
+      vane:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # fsGroup makes the fresh proxmox-csi (block) volume writable by the
+          # container regardless of its uid (fsGroup is added to supplementary
+          # groups + chowns the volume). Works on block, unlike NFS.
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        containers:
+          vane:
+            image:
+              # slim = no bundled SearXNG; we point at the existing in-cluster one.
+              repository: itzcrazykns1337/vane
+              tag: slim-v1.12.2
+            env:
+              TZ: "${TZ}"
+              # existing in-cluster SearXNG (formats already include json)
+              SEARXNG_API_URL: http://searxng.searxng.svc.cluster.local:8080
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 3000
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                # headroom for the local embeddings model running in-process
+                memory: 2Gi
+
+    service:
+      app:
+        controller: vane
+        ports:
+          http:
+            port: 3000
+
+    ingress:
+      app:
+        className: traefik
+        annotations:
+          hajimari.io/appName: "Vane"
+          hajimari.io/group: "Gen-AI"
+          hajimari.io/icon: mdi:magnify-scan
+        hosts:
+          - host: "vane.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+
+    persistence:
+      data:
+        existingClaim: vane-data
+        globalMounts:
+          - path: /home/vane/data

--- a/cluster/apps/vane/vane/app/kustomization.yaml
+++ b/cluster/apps/vane/vane/app/kustomization.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./helm-release.yaml

--- a/cluster/apps/vane/vane/app/pvc.yaml
+++ b/cluster/apps/vane/vane/app/pvc.yaml
@@ -1,0 +1,16 @@
+---
+# proxmox-csi (not NFS): Vane's data is just UI-entered config, search history,
+# and the local embeddings cache — small + regenerable, doesn't warrant the
+# duplicacy file-backup path. (User decision 2026-06-18.)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vane-data
+  namespace: vane
+spec:
+  storageClassName: proxmox-csi-ext4-ssd-zfs
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/cluster/apps/vane/vane/ks.yaml
+++ b/cluster/apps/vane/vane/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-vane
+  namespace: flux-system
+spec:
+  path: "./cluster/apps/vane/vane/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m


### PR DESCRIPTION
First consumer of the LiteLLM gateway — a self-hosted Perplexity-style research tool.

- **bjw-s app-template**, ns `vane`, image pinned `itzcrazykns1337/vane:slim-v1.12.2`
- **slim** image → points at your **existing in-cluster SearXNG** (`searxng.searxng.svc:8080`; json format already enabled) instead of bundling a duplicate
- **proxmox-csi** PVC for `/home/vane/data` (config/history/embeddings cache — small, regenerable, no backup needed per your call)
- `fsGroup` so the fresh block volume is writable; traefik ingress `vane.${SECRET_DOMAIN}`
- Local embeddings (in-process); 2Gi limit for headroom

## Post-deploy (web UI, when you're free)
Vane's LLM config is UI-only — at `https://vane.<domain>`, set the OpenAI-compatible base URL to the LiteLLM service, model `local`, embeddings = local. Persists to the volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)