### PR TITLE
searxng: disable DuckDuckGo engine (CAPTCHA-blocked)

### DIFF
--- a/cluster/apps/searxng/searxng/app/resources/settings.yaml
+++ b/cluster/apps/searxng/searxng/app/resources/settings.yaml
@@ -63,4 +63,3 @@ hostnames:
 engines:
   - name: duckduckgo
     disabled: true
-

--- a/cluster/apps/searxng/searxng/app/resources/settings.yaml
+++ b/cluster/apps/searxng/searxng/app/resources/settings.yaml
@@ -8,8 +8,8 @@ server:
   public_instance: false
 
 search:
-  autocomplete: duckduckgo
-  favicon_resolver: duckduckgo
+  autocomplete: google
+  favicon_resolver: google
   languages:
     - all
     - en
@@ -55,3 +55,12 @@ hostnames:
     - (.*\.)?stackoverflow.com$
     - (.*\.)?askubuntu.com$
     - (.*\.)?superuser.com$
+
+# DuckDuckGo serves anti-bot CAPTCHAs to this instance (SearxEngineCaptchaException),
+# which spammed errors + degraded results (incl. Vane's Discover). Its results
+# largely mirror Bing (still enabled), so disable it; merges with use_default_settings
+# by name. autocomplete/favicon_resolver also moved off DDG (above).
+engines:
+  - name: duckduckgo
+    disabled: true
+


### PR DESCRIPTION
DDG was serving anti-bot CAPTCHAs (`SearxEngineCaptchaException`) — error spam + thinner results (incl. Vane Discover). DDG ≈ Bing (still enabled), so disable it + move autocomplete/favicon off DDG. Residential egress kept (cleanest for captchas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)