### PR TITLE
searxng: re-enable DuckDuckGo (intermittent != broken)

### DIFF
--- a/cluster/apps/searxng/searxng/app/resources/settings.yaml
+++ b/cluster/apps/searxng/searxng/app/resources/settings.yaml
@@ -8,8 +8,8 @@ server:
   public_instance: false
 
 search:
-  autocomplete: google
-  favicon_resolver: google
+  autocomplete: duckduckgo
+  favicon_resolver: duckduckgo
   languages:
     - all
     - en
@@ -55,11 +55,3 @@ hostnames:
     - (.*\.)?stackoverflow.com$
     - (.*\.)?askubuntu.com$
     - (.*\.)?superuser.com$
-
-# DuckDuckGo serves anti-bot CAPTCHAs to this instance (SearxEngineCaptchaException),
-# which spammed errors + degraded results (incl. Vane's Discover). Its results
-# largely mirror Bing (still enabled), so disable it; merges with use_default_settings
-# by name. autocomplete/favicon_resolver also moved off DDG (above).
-engines:
-  - name: duckduckgo
-    disabled: true


### PR DESCRIPTION
Revert the DDG disable. DDG only fails intermittently (captcha) and still returns good results most of the time; SearXNG degrades gracefully so the errors are cosmetic. Disabling a mostly-working engine to silence log noise loses its real contributions. Net: no engines disabled, autocomplete/favicon back to DDG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)