### PR TITLE
ai: stand up llama.cpp Gemma 26B-A4B, swap from vLLM 12B

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -16,12 +16,22 @@ data:
       # api_base/model below. THIS is the whole reason LiteLLM goes in first.
       - model_name: local
         litellm_params:
-          model: openai/google/gemma-4-12B-it-qat-w4a16-ct
-          api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
-          api_key: sk-noauth   # vLLM serves without auth; placeholder is required
-      # Explicit name too, for when you want to pin the exact model.
+          # SWAPPED to the llama.cpp Gemma 26B-A4B (2026-06-19 experiment). Downstream
+          # (HA/GLaDOS, Vane) follow automatically with zero changes — the whole point
+          # of the gateway. To revert: point this back at gemma-12b/vllm + re-toggle.
+          model: openai/gemma-26b
+          api_base: http://llamacpp.ai.svc.cluster.local:8080/v1
+          api_key: sk-noauth
+      # Explicit names so you can pin a specific backend regardless of what "local" is.
+      - model_name: gemma-26b
+        litellm_params:
+          model: openai/gemma-26b
+          api_base: http://llamacpp.ai.svc.cluster.local:8080/v1
+          api_key: sk-noauth
       - model_name: gemma-12b
         litellm_params:
+          # vLLM 12B — parked (its replicaCount is 0 while the 26B holds the GPU);
+          # this alias 404s until you toggle the 12B back up.
           model: openai/google/gemma-4-12B-it-qat-w4a16-ct
           api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
           api_key: sk-noauth

--- a/cluster/apps/ai/llamacpp/app/helm-release.yaml
+++ b/cluster/apps/ai/llamacpp/app/helm-release.yaml
@@ -1,0 +1,132 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llamacpp
+  namespace: ai
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      interval: 30m
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+
+  values:
+    defaultPodOptions:
+      runtimeClassName: nvidia
+
+    controllers:
+      llamacpp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # Same GPU pattern as vllm/ollama: pin to the GPU node + runtimeClassName
+          # nvidia, NO device-plugin claim (nvidia.com/gpu: 0). Exclusivity is managed
+          # by toggling — only one GPU model runs at a time (this PR sets vllm-12b -> 0).
+          nodeSelector:
+            gpu: "true"
+        containers:
+          llamacpp:
+            image:
+              repository: ghcr.io/ggml-org/llama.cpp
+              # server-cuda, digest-pinned (rolling tag → immutable digest as of 2026-06-19).
+              tag: "server-cuda@sha256:7f3949110c2df076c197e6a2e902aa328a26a3d6249ab1a50dc9fad568dc8b97"
+            args:
+              # Unsloth dynamic QAT GGUF — recovers MoE-expert quality (70.2->85.6% vs
+              # naive q4_0). Auto-downloads to LLAMA_CACHE (the PVC) on first boot.
+              - "--hf-repo"
+              - "unsloth/gemma-4-26B-A4B-it-qat-GGUF"
+              - "--hf-file"
+              - "gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf"
+              - "-ngl"
+              - "99"
+              # f16 KV (NO -ctk/-ctv quant — Gemma SWA-cache quant = quality trap).
+              # -c 32768 conservative for first boot; KV math says far more fits (raise later).
+              - "-c"
+              - "32768"
+              - "-fa"
+              - "--host"
+              - "0.0.0.0"
+              - "--port"
+              - "8080"
+              - "--alias"
+              - "gemma-26b"
+            env:
+              TZ: "${TZ}"
+              NVIDIA_VISIBLE_DEVICES: all
+              NVIDIA_DRIVER_CAPABILITIES: all
+              LLAMA_CACHE: /models
+            probes:
+              # First boot downloads ~17GB then loads → long startup grace.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  failureThreshold: 160   # ~40 min for 17GB download + load
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 100m
+                memory: 2Gi
+                nvidia.com/gpu: 0
+              limits:
+                memory: 8Gi
+                nvidia.com/gpu: 0
+
+    service:
+      app:
+        controller: llamacpp
+        ports:
+          http:
+            port: 8080
+
+    ingress:
+      app:
+        className: traefik
+        annotations:
+          hajimari.io/appName: "llama.cpp (Gemma 26B)"
+          hajimari.io/group: "Gen-AI"
+          hajimari.io/icon: mdi:brain
+        hosts:
+          - host: "llamacpp.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+
+    persistence:
+      models:
+        existingClaim: llamacpp-models
+        globalMounts:
+          - path: /models

--- a/cluster/apps/ai/llamacpp/app/helm-release.yaml
+++ b/cluster/apps/ai/llamacpp/app/helm-release.yaml
@@ -73,7 +73,7 @@ spec:
                     port: 8080
                   initialDelaySeconds: 30
                   periodSeconds: 15
-                  failureThreshold: 160   # ~40 min for 17GB download + load
+                  failureThreshold: 160 # ~40 min for 17GB download + load
               liveness:
                 enabled: true
                 custom: true

--- a/cluster/apps/ai/llamacpp/app/kustomization.yaml
+++ b/cluster/apps/ai/llamacpp/app/kustomization.yaml
@@ -3,7 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./vllm/ks.yaml
-  - ./litellm/ks.yaml
-  - ./llamacpp/ks.yaml
+  - ./pvc.yaml
+  - ./helm-release.yaml

--- a/cluster/apps/ai/llamacpp/app/pvc.yaml
+++ b/cluster/apps/ai/llamacpp/app/pvc.yaml
@@ -1,0 +1,15 @@
+---
+# proxmox-csi for the GGUF cache — the model file is large (~17GB) but regenerable
+# (re-downloadable from HF), so no NFS/backup needed (same call as Vane).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llamacpp-models
+  namespace: ai
+spec:
+  storageClassName: proxmox-csi-ext4-ssd-zfs
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi

--- a/cluster/apps/ai/llamacpp/ks.yaml
+++ b/cluster/apps/ai/llamacpp/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-llamacpp
+  namespace: flux-system
+spec:
+  path: "./cluster/apps/ai/llamacpp/app"
+  dependsOn:
+    - name: cluster-apps-nvidia-device-plugin
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/cluster/apps/ai/vllm/app/helm-release.yaml
+++ b/cluster/apps/ai/vllm/app/helm-release.yaml
@@ -110,7 +110,10 @@ spec:
           repository: vllm/vllm-openai
           tag: nightly-2c9c07c85e56c799afffd5a671a8a0bace377a39
           modelURL: google/gemma-4-12B-it-qat-w4a16-ct
-          replicaCount: 1
+          # Toggled to 0 while the llama.cpp Gemma 26B-A4B holds the GPU (one model
+          # per 3090). Flip back to 1 (+ repoint LiteLLM `local`→gemma-12b, scale
+          # llamacpp to 0) to restore the 12B.
+          replicaCount: 0
           requestCPU: 0
           requestMemory: 4Gi
           requestGPU: 0


### PR DESCRIPTION
Phase-2 experiment: serve **Gemma 4 26B-A4B** (Unsloth UD-Q4_K_XL QAT GGUF) on **llama.cpp**, swapping the GPU from the vLLM 12B. Doubles as the **raw-llama-server 24/7-stability + engine test**.

## What's in it
- **New `llamacpp` app** (bjw-s, ns `ai`): `ghcr.io/ggml-org/llama.cpp` server-cuda (digest-pinned), `--hf` auto-download of `unsloth/gemma-4-26B-A4B-it-qat-GGUF` UD-Q4_K_XL (~17GB) → proxmox-csi PVC; `-ngl 99`, **f16 KV** (Gemma SWA-quant trap), `-c 32768` (conservative; raise later), `-fa`, OpenAI `/v1`, alias `gemma-26b`.
- **vLLM 12B → replicaCount 0** (frees the GPU — one model per 3090).
- **LiteLLM `local` → llamacpp** → GLaDOS/Vane swap to the 26B with **zero downstream changes** (the gateway payoff). `gemma-26b` alias added; `gemma-12b` kept (parked).

## ⚠️ Merging this IS the cutover
12B goes down → 26B pod downloads (~17GB) + loads → `local` serves 26B. There's a **downtime window** (first-boot download+load) where GLaDOS/Vane error. Startup probe allows ~40 min grace. Subsequent boots are fast (GGUF cached on PVC).

**Rollback** (if 26B misbehaves): flip vLLM 12B → 1, LiteLLM `local` → `gemma-12b`, llamacpp → 0 — service back in ~2 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)