### PR TITLE
litellm: rename gemma aliases to gemma4-{12b,26b}

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -18,17 +18,17 @@ data:
         litellm_params:
           # SWAPPED to the llama.cpp Gemma 26B-A4B (2026-06-19 experiment). Downstream
           # (HA/GLaDOS, Vane) follow automatically with zero changes — the whole point
-          # of the gateway. To revert: point this back at gemma-12b/vllm + re-toggle.
+          # of the gateway. To revert: point this back at gemma4-12b/vllm + re-toggle.
           model: openai/gemma-26b
           api_base: http://llamacpp.ai.svc.cluster.local:8080/v1
           api_key: sk-noauth
       # Explicit names so you can pin a specific backend regardless of what "local" is.
-      - model_name: gemma-26b
+      - model_name: gemma4-26b
         litellm_params:
           model: openai/gemma-26b
           api_base: http://llamacpp.ai.svc.cluster.local:8080/v1
           api_key: sk-noauth
-      - model_name: gemma-12b
+      - model_name: gemma4-12b
         litellm_params:
           # vLLM 12B — parked (its replicaCount is 0 while the 26B holds the GPU);
           # this alias 404s until you toggle the 12B back up.


### PR DESCRIPTION
Minor naming fix: the local models are Gemma **4** family, so the LiteLLM `model_name` aliases should say so.

- `gemma-26b` → `gemma4-26b`
- `gemma-12b` → `gemma4-12b`

Public aliases only. The stable `local` alias and the backend `model:`/`api_base` params are unchanged, so nothing downstream re-plumbs (HA/GLaDOS/Vane all use `local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)