### PR TITLE
ai: revert to vLLM Gemma 4 12B (vision on); park llama.cpp 26B

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -16,16 +16,18 @@ data:
       # api_base/model below. THIS is the whole reason LiteLLM goes in first.
       - model_name: local
         litellm_params:
-          # SWAPPED to the llama.cpp Gemma 26B-A4B (2026-06-19 experiment). Downstream
-          # (HA/GLaDOS, Vane) follow automatically with zero changes — the whole point
-          # of the gateway. To revert: point this back at gemma4-12b/vllm + re-toggle.
-          model: openai/gemma-26b
-          api_base: http://llamacpp.ai.svc.cluster.local:8080/v1
+          # Back on the vLLM Gemma 4 12B (2026-06-19): the llama.cpp 26B-A4B was
+          # abandoned — Gemma-4 thinking on llama.cpp has open upstream termination
+          # bugs (peg-gemma4 parser loop ggml-org/llama.cpp#21375 + INT_MAX
+          # reasoning-budget default) that hang the model. Downstream (HA/GLaDOS,
+          # Vane) follow automatically — the whole point of the gateway.
+          model: openai/google/gemma-4-12B-it-qat-w4a16-ct
+          api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
           api_key: sk-noauth
       # Explicit names so you can pin a specific backend regardless of what "local" is.
       - model_name: gemma4-26b
         litellm_params:
-          model: openai/gemma-26b
+          model: openai/gemma4-26b
           api_base: http://llamacpp.ai.svc.cluster.local:8080/v1
           api_key: sk-noauth
       - model_name: gemma4-12b

--- a/cluster/apps/ai/llamacpp/app/helm-release.yaml
+++ b/cluster/apps/ai/llamacpp/app/helm-release.yaml
@@ -23,6 +23,12 @@ spec:
 
     controllers:
       llamacpp:
+        # Parked at 0 — the Gemma 26B-A4B experiment was abandoned (open upstream
+        # Gemma-4 thinking termination bugs on llama.cpp: peg-gemma4 parser loop
+        # ggml-org/llama.cpp#21375 + INT_MAX reasoning-budget default = hangs).
+        # vLLM Gemma 4 12B is the daily driver. Flip to 1 to revisit when upstream
+        # fixes land (and scale vllm gemma4-12b-qat -> 0; one model per 3090).
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
         pod:
@@ -61,7 +67,7 @@ spec:
               - "--port"
               - "8080"
               - "--alias"
-              - "gemma-26b"
+              - "gemma4-26b"
             env:
               TZ: "${TZ}"
               NVIDIA_VISIBLE_DEVICES: all

--- a/cluster/apps/ai/vllm/app/helm-release.yaml
+++ b/cluster/apps/ai/vllm/app/helm-release.yaml
@@ -104,16 +104,16 @@ spec:
         # maxModelLen 131072: 8/48 layers are full-attention (rest sliding
         # window 1024), so KV is ~64KB/token + ~0.3GB fixed → ~8.3GB at 128k,
         # alongside ~8GB W4A16 weights within the 0.90 budget on the 24GB 3090.
-        # Multimodal input stays disabled (limit-mm-per-prompt 0) to keep the
-        # full KV budget for text context; remove that flag to enable images.
+        # Multimodal ENABLED (limit-mm-per-prompt image:1) — HA vision tasks need it.
+        # The encoder-free unified arch carries the image as ~280 soft tokens, so KV
+        # cost is modest; if startup OOMs at 131072, trim maxModelLen.
         - name: gemma4-12b-qat
           repository: vllm/vllm-openai
           tag: nightly-2c9c07c85e56c799afffd5a671a8a0bace377a39
           modelURL: google/gemma-4-12B-it-qat-w4a16-ct
-          # Toggled to 0 while the llama.cpp Gemma 26B-A4B holds the GPU (one model
-          # per 3090). Flip back to 1 (+ repoint LiteLLM `local`→gemma-12b, scale
-          # llamacpp to 0) to restore the 12B.
-          replicaCount: 0
+          # LIVE — daily driver. (The llama.cpp 26B-A4B experiment was abandoned:
+          # open upstream Gemma-4 thinking termination bugs hang it. llamacpp -> 0.)
+          replicaCount: 1
           requestCPU: 0
           requestMemory: 4Gi
           requestGPU: 0
@@ -135,7 +135,7 @@ spec:
               - "--hf-overrides"
               - '{"vision_config": {"num_soft_tokens": 280}}'
               - "--limit-mm-per-prompt"
-              - '{"image": 0, "audio": 0}'
+              - '{"image": 1, "audio": 0}'
 
           shmSize: 8Gi
 


### PR DESCRIPTION
## Why
The llama.cpp Gemma 26B-A4B experiment is abandoned. Gemma-4 *thinking* on current llama.cpp has **open upstream termination bugs** — the `peg-gemma4` parser infinite loop ([ggml-org/llama.cpp#21375](https://github.com/ggml-org/llama.cpp/issues/21375)) plus the `INT_MAX` reasoning-budget default — that hang the model (confirmed: runaway in Vane, knock-knock prompts never returning). We were already on the latest `server-cuda` build **and** the latest GGUF, so there was nothing left to bump, and a budget cap would only paper over the upstream bug.

## Changes
- **vllm** `gemma4-12b-qat`: `replicaCount` 0 → 1; `--limit-mm-per-prompt` `image` 0 → 1 (HA vision tasks need multimodal — the encoder-free unified arch carries an image as ~280 soft tokens, so KV cost is modest).
- **llamacpp**: controller `replicas` → 0 (frees the GPU; one model per 3090).
- **litellm**: `local` → back to the 12B at `vllm-router`. Downstream (HA/GLaDOS, Vane) follow automatically.

## Watch on deploy
12B startup at `maxModelLen: 131072` with vision now enabled — if it OOMs during profiling, trim `maxModelLen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)