### PR TITLE
monitoring: move Prometheus TSDB to HDD (pve-bulk) + retentionSize cap

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -250,16 +250,21 @@ spec:
                 target_label: __param_target
               - target_label: __address__
                 replacement: ${NFS_SERVER}:9221
-        #retention: 6h
+        # retentionSize is the real safety valve on a fixed-size disk: Prometheus
+        # GCs by size before it can ever hit ENOSPC (a full 10Gi SSD PVC wedged
+        # the TSDB 2026-06-20 → blind 5d). Keep it comfortably under the PVC size.
+        retention: 30d
+        retentionSize: "45GiB"
         enableAdminAPI: true
         walCompression: true
         storageSpec:
           volumeClaimTemplate:
             spec:
-              storageClassName: proxmox-csi-ext4-ssd
+              # HDD-backed bulk: TSDB is write-heavy + disposable, no need for SSD.
+              storageClassName: proxmox-csi-hdd
               resources:
                 requests:
-                  storage: 10Gi
+                  storage: 50Gi
         securityContext:
           runAsGroup: 2316
           runAsNonRoot: true

--- a/cluster/apps/proxmox-csi/proxmox-csi/app/helm-release.yaml
+++ b/cluster/apps/proxmox-csi/proxmox-csi/app/helm-release.yaml
@@ -48,5 +48,14 @@ spec:
         fstype: ext4
         storage: local-zfs
         ssd: true
+      # HDD-backed (pve-bulk) for write-heavy, disposable data like the
+      # Prometheus TSDB: keeps it on block (NFS corrupts TSDB) but off the
+      # expensive/high-wear SSD tier. Delete reclaim — data is throwaway, so
+      # no orphaned Released PVs to hand-clean on every recreate.
+      - name: proxmox-csi-hdd
+        reclaimPolicy: Delete
+        fstype: ext4
+        storage: pve-bulk
+        ssd: false
     existingConfigSecret: "proxmox-csi-cluster-config"
     existingConfigSecretKey: "config"


### PR DESCRIPTION
## What & why

The Prometheus PVC hit 100% on **2026-06-20 12:44** and wedged the TSDB (`no space left on device` on WAL writes). Scrapes still returned `health=up` but no samples — including the synthetic `up` — could be committed, so the `absent(up{...})` rules (`KubeAPIDown` / `KubeControllerManagerDown` / `KubeSchedulerDown` / `KubeProxyDown`) fired and the **whole cluster went unmonitored for ~5 days**. The control-plane alerts were symptoms; the cluster itself was healthy throughout.

Two root causes, both fixed:

1. **No size cap.** `retention` was commented out and there was no `retentionSize`, so the TSDB grew past the fixed 10Gi PVC. Adds `retentionSize: "45GiB"` (hard cap — Prometheus GCs by size *before* ENOSPC) + explicit `retention: 30d`.
2. **Wrong storage tier.** The TSDB is write-heavy (constant WAL + ~2h compaction rewrites) and disposable — expensive, high-wear SSD is the wrong home. Adds a non-SSD `proxmox-csi-hdd` class on `pve-bulk` and moves the TSDB to it at 50Gi. Stays on block (NFS corrupts TSDB) but off SSD.

## Manual step after merge + reconcile

A StatefulSet `volumeClaimTemplate` (class + size) is immutable, so the operator won't migrate the PVC on its own. Once `kubectl get sc` shows `proxmox-csi-hdd`:

\`\`\`
kubectl -n monitoring delete statefulset prometheus-kube-prometheus-stack-prometheus --cascade=orphan
kubectl -n monitoring delete pvc prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0
kubectl -n monitoring delete pod prometheus-kube-prometheus-stack-prometheus-0
\`\`\`

Operator rebuilds the STS → fresh 50Gi PVC on `pve-bulk`. The old 10Gi SSD PV (reclaim `Retain`) lingers as `Released` for manual cleanup. Alerts clear once `up` starts writing again. TSDB history is already lost to the full disk, so nothing extra is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)