### PR TITLE
vllm: re-pin image to v0.24.0 (pruned nightly tag broke pulls)

### DIFF
--- a/cluster/apps/ai/vllm/app/helm-release.yaml
+++ b/cluster/apps/ai/vllm/app/helm-release.yaml
@@ -99,8 +99,9 @@ spec:
         # field unconditionally at gemma4_unified.py:166/:197. Workaround:
         # inject it via --hf-overrides. 280 is the value shipped in the BF16
         # sibling google/gemma-4-12B-it config — not a guess.
-        # The unified arch is still nightly-only: v0.22.1 (latest stable,
-        # 2026-06-05) does not register Gemma4UnifiedForConditionalGeneration.
+        # Image pinned to v0.24.0 stable (contains the unified arch; the
+        # previously pinned nightly-2c9c07c tag was pruned from Docker Hub —
+        # nightly-<sha> tags only live ~10 days upstream, never pin them).
         # maxModelLen 131072: 8/48 layers are full-attention (rest sliding
         # window 1024), so KV is ~64KB/token + ~0.3GB fixed → ~8.3GB at 128k,
         # alongside ~8GB W4A16 weights within the 0.90 budget on the 24GB 3090.
@@ -109,7 +110,7 @@ spec:
         # cost is modest; if startup OOMs at 131072, trim maxModelLen.
         - name: gemma4-12b-qat
           repository: vllm/vllm-openai
-          tag: nightly-2c9c07c85e56c799afffd5a671a8a0bace377a39
+          tag: v0.24.0
           modelURL: google/gemma-4-12B-it-qat-w4a16-ct
           # LIVE — daily driver. (The llama.cpp 26B-A4B experiment was abandoned:
           # open upstream Gemma-4 thinking termination bugs hang it. llamacpp -> 0.)
@@ -187,7 +188,7 @@ spec:
         # Text-only (limit-mm 0) to preserve KV budget. Dense → ~42 t/s.
         - name: gemma4-31b-qat
           repository: vllm/vllm-openai
-          tag: nightly-2c9c07c85e56c799afffd5a671a8a0bace377a39
+          tag: v0.24.0
           modelURL: google/gemma-4-31B-it-qat-w4a16-ct
           replicaCount: 0
           requestCPU: 0


### PR DESCRIPTION
## Problem

The 12B pod is in `ImagePullBackOff`: the pinned `vllm/vllm-openai:nightly-2c9c07c85e…` tag (2026-06-10) has been **pruned from Docker Hub** — vLLM only keeps a rolling ~10-day window of `nightly-<sha>` tags. The image is no longer cached on any node, so the replacement pod can't start.

## Fix

Re-pin both modelSpecs (live 12B + parked 31B) to **`v0.24.0`** (released 2026-06-29).

Verified via the GitHub compare API that `v0.24.0` fully contains the pinned nightly commit (`status: behind`, `ahead_by: 0` → strict superset), so the Gemma 4 unified arch that originally forced the nightly pin is included. `v0.23.0` does *not* contain it (missing 69 of the nightly's commits) and was skipped.

The `num_soft_tokens: 280` hf-override stays until vllm#45039 is confirmed fixed (harmless if it is).

## Post-merge checks

- [ ] Pod pulls and reaches 1/1
- [ ] Startup log: "GPU KV cache size" in the expected ~11 GiB range at maxModelLen 131072
- [ ] Tool call through the router + a vision request via LiteLLM `local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)