### PR TITLE
monitoring: add Proxmox + Node Exporter Full Grafana dashboards

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -134,6 +134,19 @@ spec:
                 path: /var/lib/grafana/dashboards/default
       dashboards:
         default:
+          # Proxmox host/VM/storage view from the pve-shodan exporter job.
+          # Ref: https://grafana.com/grafana/dashboards/10347
+          proxmox-via-prometheus:
+            gnetId: 10347
+            revision: 5
+            datasource: Prometheus
+          # Host-level metrics with a plain instance selector — covers the
+          # node-shodan job, which the stock k8s Nodes dashboards filter out.
+          # Ref: https://grafana.com/grafana/dashboards/1860
+          node-exporter-full:
+            gnetId: 1860
+            revision: 45
+            datasource: Prometheus
           # Ref: https://grafana.com/grafana/dashboards/11315
           unifi-client-insights:
             gnetId: 11315


### PR DESCRIPTION
## Summary
- Add **Proxmox via Prometheus** (gnetId 10347 rev 5) — visualizes the `pve_*` metrics from the `pve-shodan` exporter job: per-VM/LXC cpu/mem/disk, storage pools, node overview
- Add **Node Exporter Full** (gnetId 1860 rev 45) — host-level view with a plain instance selector; the stock Nodes dashboards only show kubelet-discovered cluster nodes, so the `node-shodan` job never appears in them

Both jobs have been scraping since #1521 with no dashboard consuming them. Follows the existing pinned-`gnetId` pattern used by the unifi dashboards.

## Test plan
- [x] `kubectl kustomize` builds clean
- [ ] After merge: Flux reconciles, Grafana restarts, both dashboards appear under the default folder; Proxmox board populated for instance `shodan`, Node Exporter Full shows `shodan` in the instance dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GySFiuZLDE8fKS7eDTRriJ