### PR TITLE
monitoring: fix proxmox dashboard datasource (list-form mapping)

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -135,11 +135,18 @@ spec:
       dashboards:
         default:
           # Proxmox host/VM/storage view from the pve-shodan exporter job.
+          # This board uses an import-time ${DS_PROMETHEUS} input (not a
+          # template variable), so it needs the list-form mapping — the
+          # string form only rewrites legacy "datasource": lines and left
+          # every panel pointing at a nonexistent datasource. The value is
+          # the datasource UID, since the placeholder sits in uid fields.
           # Ref: https://grafana.com/grafana/dashboards/10347
           proxmox-via-prometheus:
             gnetId: 10347
             revision: 5
-            datasource: Prometheus
+            datasource:
+              - name: DS_PROMETHEUS
+                value: prometheus
           # Host-level metrics with a plain instance selector — covers the
           # node-shodan job, which the stock k8s Nodes dashboards filter out.
           # Ref: https://grafana.com/grafana/dashboards/1860


### PR DESCRIPTION
## Summary
Follow-up to #1572 — the Proxmox board rendered empty because 10347 rev 5 uses an import-time `${DS_PROMETHEUS}` input in datasource **uid** fields. The chart's string-form `datasource:` option only rewrites legacy `"datasource":` lines, so the placeholder survived and every panel pointed at a nonexistent datasource. The list-form mapping seds `${DS_PROMETHEUS}` → `prometheus` (the datasource uid) at download time.

node-exporter-full stays on the string form: its `${ds_prometheus}` is a genuine template variable (datasource picker) that resolves at view time.

## Test plan
- [x] `kubectl kustomize` builds clean
- [ ] After merge: grafana pod rolls, `proxmox-via-prometheus.json` contains no `${DS_PROMETHEUS}`, board shows data for instance `shodan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GySFiuZLDE8fKS7eDTRriJ