### PR TITLE
monitoring: ZFS pool monitoring — scrape job, dashboards, alerts

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-arc.json
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-arc.json
@@ -1,0 +1,766 @@
+{
+ "annotations": {
+  "list": [
+   {
+    "builtIn": 1,
+    "datasource": "prometheus",
+    "enable": true,
+    "hide": true,
+    "iconColor": "rgba(0, 211, 255, 1)",
+    "name": "Annotations & Alerts",
+    "type": "dashboard"
+   }
+  ]
+ },
+ "description": "Graphs ZFS ARC and ARC L2 Hit %, Hits, Misses, Size, and Zpool",
+ "editable": true,
+ "gnetId": 7845,
+ "graphTooltip": 0,
+ "id": null,
+ "iteration": 1574354030467,
+ "links": [],
+ "panels": [
+  {
+   "aliasColors": {},
+   "bars": false,
+   "dashLength": 10,
+   "dashes": false,
+   "datasource": "prometheus",
+   "decimals": 0,
+   "fill": 1,
+   "fillGradient": 0,
+   "gridPos": {
+    "h": 6,
+    "w": 12,
+    "x": 0,
+    "y": 9
+   },
+   "id": 14,
+   "legend": {
+    "alignAsTable": false,
+    "avg": true,
+    "current": false,
+    "hideEmpty": false,
+    "hideZero": false,
+    "max": false,
+    "min": false,
+    "rightSide": false,
+    "show": true,
+    "sideWidth": 350,
+    "total": false,
+    "values": true
+   },
+   "lines": true,
+   "linewidth": 1,
+   "links": [],
+   "nullPointMode": "null",
+   "options": {
+    "dataLinks": []
+   },
+   "percentage": false,
+   "pointradius": 5,
+   "points": false,
+   "renderer": "flot",
+   "seriesOverrides": [],
+   "spaceLength": 10,
+   "stack": false,
+   "steppedLine": false,
+   "targets": [
+    {
+     "expr": "irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_demand_data_misses{instance=~\"$node\"}[5m])) * 100",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "data",
+     "refId": "A",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_demand_metadata_misses{instance=~\"$node\"}[5m])) * 100",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "metadata",
+     "refId": "B",
+     "step": 2,
+     "target": ""
+    }
+   ],
+   "thresholds": [],
+   "timeFrom": null,
+   "timeRegions": [],
+   "timeShift": null,
+   "title": "ARC - Hit %",
+   "tooltip": {
+    "shared": true,
+    "sort": 2,
+    "value_type": "individual"
+   },
+   "type": "graph",
+   "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+   },
+   "yaxes": [
+    {
+     "format": "percent",
+     "label": "",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    },
+    {
+     "format": "short",
+     "label": null,
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    }
+   ],
+   "yaxis": {
+    "align": false,
+    "alignLevel": null
+   }
+  },
+  {
+   "aliasColors": {},
+   "bars": false,
+   "dashLength": 10,
+   "dashes": false,
+   "datasource": "prometheus",
+   "decimals": 0,
+   "fill": 1,
+   "fillGradient": 0,
+   "gridPos": {
+    "h": 6,
+    "w": 12,
+    "x": 12,
+    "y": 9
+   },
+   "id": 13,
+   "legend": {
+    "alignAsTable": false,
+    "avg": false,
+    "current": false,
+    "max": false,
+    "min": false,
+    "rightSide": false,
+    "show": true,
+    "sideWidth": 350,
+    "total": true,
+    "values": true
+   },
+   "lines": true,
+   "linewidth": 1,
+   "links": [],
+   "nullPointMode": "null",
+   "options": {
+    "dataLinks": []
+   },
+   "percentage": false,
+   "pointradius": 5,
+   "points": false,
+   "renderer": "flot",
+   "seriesOverrides": [],
+   "spaceLength": 10,
+   "stack": false,
+   "steppedLine": false,
+   "targets": [
+    {
+     "expr": "irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m])",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "data_hits",
+     "refId": "A",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m])",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "metadata_hits",
+     "refId": "B",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "irate(node_zfs_arc_demand_data_misses{instance=~\"$node\"}[5m])",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "data_misses",
+     "refId": "C",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "irate(node_zfs_arc_demand_metadata_misses{instance=~\"$node\"}[5m])",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "metadata_misses",
+     "refId": "D",
+     "step": 2,
+     "target": ""
+    }
+   ],
+   "thresholds": [],
+   "timeFrom": null,
+   "timeRegions": [],
+   "timeShift": null,
+   "title": "ARC - Hits, Misses",
+   "tooltip": {
+    "shared": true,
+    "sort": 2,
+    "value_type": "individual"
+   },
+   "type": "graph",
+   "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+   },
+   "yaxes": [
+    {
+     "format": "none",
+     "label": "",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    },
+    {
+     "format": "short",
+     "label": null,
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    }
+   ],
+   "yaxis": {
+    "align": false,
+    "alignLevel": null
+   }
+  },
+  {
+   "aliasColors": {},
+   "bars": false,
+   "dashLength": 10,
+   "dashes": false,
+   "datasource": "prometheus",
+   "fill": 1,
+   "fillGradient": 0,
+   "gridPos": {
+    "h": 7,
+    "w": 24,
+    "x": 0,
+    "y": 15
+   },
+   "id": 15,
+   "legend": {
+    "alignAsTable": true,
+    "avg": true,
+    "current": true,
+    "max": true,
+    "min": true,
+    "rightSide": true,
+    "show": true,
+    "sideWidth": 350,
+    "total": false,
+    "values": true
+   },
+   "lines": true,
+   "linewidth": 1,
+   "links": [],
+   "nullPointMode": "null",
+   "options": {
+    "dataLinks": []
+   },
+   "percentage": false,
+   "pointradius": 5,
+   "points": false,
+   "renderer": "flot",
+   "seriesOverrides": [],
+   "spaceLength": 10,
+   "stack": true,
+   "steppedLine": false,
+   "targets": [
+    {
+     "expr": "node_zfs_arc_data_size{instance=~\"$node\"}",
+     "format": "time_series",
+     "hide": false,
+     "interval": "",
+     "intervalFactor": 2,
+     "legendFormat": "data",
+     "refId": "I",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "node_zfs_arc_metadata_size{instance=~\"$node\"}",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "metadata",
+     "refId": "D",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "node_zfs_arc_anon_size{instance=~\"$node\"}",
+     "format": "time_series",
+     "hide": false,
+     "interval": "",
+     "intervalFactor": 2,
+     "legendFormat": "anon",
+     "refId": "B",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "node_zfs_arc_hdr_size{instance=~\"$node\"}",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "hdr",
+     "refId": "C",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "node_zfs_arc_other_size{instance=~\"$node\"}",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "other",
+     "refId": "J",
+     "step": 2,
+     "target": ""
+    }
+   ],
+   "thresholds": [],
+   "timeFrom": null,
+   "timeRegions": [],
+   "timeShift": null,
+   "title": "ARC - Size",
+   "tooltip": {
+    "shared": true,
+    "sort": 2,
+    "value_type": "individual"
+   },
+   "type": "graph",
+   "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+   },
+   "yaxes": [
+    {
+     "format": "bytes",
+     "label": "",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    },
+    {
+     "format": "short",
+     "label": null,
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    }
+   ],
+   "yaxis": {
+    "align": false,
+    "alignLevel": null
+   }
+  },
+  {
+   "aliasColors": {},
+   "bars": false,
+   "dashLength": 10,
+   "dashes": false,
+   "datasource": "prometheus",
+   "decimals": 0,
+   "fill": 1,
+   "fillGradient": 0,
+   "gridPos": {
+    "h": 7,
+    "w": 12,
+    "x": 0,
+    "y": 23
+   },
+   "id": 16,
+   "legend": {
+    "alignAsTable": true,
+    "avg": true,
+    "current": false,
+    "hideEmpty": false,
+    "hideZero": false,
+    "max": false,
+    "min": false,
+    "rightSide": true,
+    "show": true,
+    "sideWidth": 350,
+    "total": false,
+    "values": true
+   },
+   "lines": true,
+   "linewidth": 1,
+   "links": [],
+   "nullPointMode": "null",
+   "options": {
+    "dataLinks": []
+   },
+   "percentage": false,
+   "pointradius": 5,
+   "points": false,
+   "renderer": "flot",
+   "seriesOverrides": [],
+   "spaceLength": 10,
+   "stack": false,
+   "steppedLine": false,
+   "targets": [
+    {
+     "expr": "irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_l2_misses{instance=~\"$node\"}[5m])) * 100",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "L2",
+     "refId": "A",
+     "step": 2,
+     "target": ""
+    }
+   ],
+   "thresholds": [],
+   "timeFrom": null,
+   "timeRegions": [],
+   "timeShift": null,
+   "title": "ARC L2 - Hit %",
+   "tooltip": {
+    "shared": true,
+    "sort": 2,
+    "value_type": "individual"
+   },
+   "type": "graph",
+   "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+   },
+   "yaxes": [
+    {
+     "format": "percent",
+     "label": "",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    },
+    {
+     "format": "short",
+     "label": null,
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    }
+   ],
+   "yaxis": {
+    "align": false,
+    "alignLevel": null
+   }
+  },
+  {
+   "aliasColors": {},
+   "bars": false,
+   "dashLength": 10,
+   "dashes": false,
+   "datasource": "prometheus",
+   "decimals": 0,
+   "fill": 1,
+   "fillGradient": 0,
+   "gridPos": {
+    "h": 7,
+    "w": 12,
+    "x": 12,
+    "y": 23
+   },
+   "id": 17,
+   "legend": {
+    "alignAsTable": true,
+    "avg": false,
+    "current": false,
+    "max": false,
+    "min": false,
+    "rightSide": true,
+    "show": true,
+    "sideWidth": 350,
+    "total": true,
+    "values": true
+   },
+   "lines": true,
+   "linewidth": 1,
+   "links": [],
+   "nullPointMode": "null",
+   "options": {
+    "dataLinks": []
+   },
+   "percentage": false,
+   "pointradius": 5,
+   "points": false,
+   "renderer": "flot",
+   "seriesOverrides": [],
+   "spaceLength": 10,
+   "stack": false,
+   "steppedLine": false,
+   "targets": [
+    {
+     "expr": "irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m])",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "hits",
+     "refId": "A",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "irate(node_zfs_arc_l2_misses{instance=~\"$node\"}[5m])",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "misses",
+     "refId": "B",
+     "step": 2,
+     "target": ""
+    }
+   ],
+   "thresholds": [],
+   "timeFrom": null,
+   "timeRegions": [],
+   "timeShift": null,
+   "title": "ARC L2 - Hits, Misses",
+   "tooltip": {
+    "shared": true,
+    "sort": 2,
+    "value_type": "individual"
+   },
+   "type": "graph",
+   "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+   },
+   "yaxes": [
+    {
+     "format": "none",
+     "label": "",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    },
+    {
+     "format": "short",
+     "label": null,
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    }
+   ],
+   "yaxis": {
+    "align": false,
+    "alignLevel": null
+   }
+  },
+  {
+   "aliasColors": {},
+   "bars": false,
+   "dashLength": 10,
+   "dashes": false,
+   "datasource": "prometheus",
+   "fill": 1,
+   "fillGradient": 0,
+   "gridPos": {
+    "h": 7,
+    "w": 24,
+    "x": 0,
+    "y": 30
+   },
+   "id": 18,
+   "legend": {
+    "alignAsTable": true,
+    "avg": true,
+    "current": false,
+    "max": true,
+    "min": true,
+    "rightSide": true,
+    "show": true,
+    "sideWidth": 350,
+    "total": false,
+    "values": true
+   },
+   "lines": true,
+   "linewidth": 1,
+   "links": [],
+   "nullPointMode": "null",
+   "options": {
+    "dataLinks": []
+   },
+   "percentage": false,
+   "pointradius": 5,
+   "points": false,
+   "renderer": "flot",
+   "seriesOverrides": [],
+   "spaceLength": 10,
+   "stack": true,
+   "steppedLine": false,
+   "targets": [
+    {
+     "expr": "node_zfs_arc_l2_asize{instance=~\"$node\"}",
+     "format": "time_series",
+     "hide": false,
+     "interval": "",
+     "intervalFactor": 2,
+     "legendFormat": "asize",
+     "refId": "I",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "node_zfs_arc_l2_hdr_size{instance=~\"$node\"}",
+     "format": "time_series",
+     "intervalFactor": 2,
+     "legendFormat": "metadata",
+     "refId": "D",
+     "step": 2,
+     "target": ""
+    },
+    {
+     "expr": "node_zfs_arc_l2_size{instance=~\"$node\"}",
+     "format": "time_series",
+     "hide": false,
+     "interval": "",
+     "intervalFactor": 2,
+     "legendFormat": "size",
+     "refId": "B",
+     "step": 2,
+     "target": ""
+    }
+   ],
+   "thresholds": [],
+   "timeFrom": null,
+   "timeRegions": [],
+   "timeShift": null,
+   "title": "ARC L2 - Size",
+   "tooltip": {
+    "shared": true,
+    "sort": 2,
+    "value_type": "individual"
+   },
+   "type": "graph",
+   "xaxis": {
+    "buckets": null,
+    "mode": "time",
+    "name": null,
+    "show": true,
+    "values": []
+   },
+   "yaxes": [
+    {
+     "format": "bytes",
+     "label": "",
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    },
+    {
+     "format": "short",
+     "label": null,
+     "logBase": 1,
+     "max": null,
+     "min": null,
+     "show": true
+    }
+   ],
+   "yaxis": {
+    "align": false,
+    "alignLevel": null
+   }
+  }
+ ],
+ "refresh": "10s",
+ "schemaVersion": 20,
+ "style": "dark",
+ "tags": [],
+ "templating": {
+  "list": [
+   {
+    "allValue": null,
+    "current": {},
+    "datasource": "prometheus",
+    "definition": "label_values(node_zfs_arc_size, instance)",
+    "hide": 0,
+    "includeAll": false,
+    "label": null,
+    "multi": false,
+    "name": "node",
+    "options": [],
+    "query": "label_values(node_zfs_arc_size, instance)",
+    "refresh": 1,
+    "regex": "/([^:]+):.*/",
+    "skipUrlSync": false,
+    "sort": 1,
+    "tagValuesQuery": "",
+    "tags": [],
+    "tagsQuery": "",
+    "type": "query",
+    "useTags": false
+   }
+  ]
+ },
+ "time": {
+  "from": "now-30m",
+  "to": "now"
+ },
+ "timepicker": {
+  "refresh_intervals": [
+   "5s",
+   "10s",
+   "30s",
+   "1m",
+   "5m",
+   "15m",
+   "30m",
+   "1h",
+   "2h",
+   "1d"
+  ],
+  "time_options": [
+   "5m",
+   "15m",
+   "1h",
+   "6h",
+   "12h",
+   "24h",
+   "2d",
+   "7d",
+   "30d"
+  ]
+ },
+ "timezone": "browser",
+ "title": "ZFS ARC",
+ "uid": "zfs-arc",
+ "version": 1
+}

--- a/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-arc.json
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-arc.json
@@ -1,766 +1,756 @@
 {
- "annotations": {
-  "list": [
-   {
-    "builtIn": 1,
-    "datasource": "prometheus",
-    "enable": true,
-    "hide": true,
-    "iconColor": "rgba(0, 211, 255, 1)",
-    "name": "Annotations & Alerts",
-    "type": "dashboard"
-   }
-  ]
- },
- "description": "Graphs ZFS ARC and ARC L2 Hit %, Hits, Misses, Size, and Zpool",
- "editable": true,
- "gnetId": 7845,
- "graphTooltip": 0,
- "id": null,
- "iteration": 1574354030467,
- "links": [],
- "panels": [
-  {
-   "aliasColors": {},
-   "bars": false,
-   "dashLength": 10,
-   "dashes": false,
-   "datasource": "prometheus",
-   "decimals": 0,
-   "fill": 1,
-   "fillGradient": 0,
-   "gridPos": {
-    "h": 6,
-    "w": 12,
-    "x": 0,
-    "y": 9
-   },
-   "id": 14,
-   "legend": {
-    "alignAsTable": false,
-    "avg": true,
-    "current": false,
-    "hideEmpty": false,
-    "hideZero": false,
-    "max": false,
-    "min": false,
-    "rightSide": false,
-    "show": true,
-    "sideWidth": 350,
-    "total": false,
-    "values": true
-   },
-   "lines": true,
-   "linewidth": 1,
-   "links": [],
-   "nullPointMode": "null",
-   "options": {
-    "dataLinks": []
-   },
-   "percentage": false,
-   "pointradius": 5,
-   "points": false,
-   "renderer": "flot",
-   "seriesOverrides": [],
-   "spaceLength": 10,
-   "stack": false,
-   "steppedLine": false,
-   "targets": [
-    {
-     "expr": "irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_demand_data_misses{instance=~\"$node\"}[5m])) * 100",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "data",
-     "refId": "A",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_demand_metadata_misses{instance=~\"$node\"}[5m])) * 100",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "metadata",
-     "refId": "B",
-     "step": 2,
-     "target": ""
-    }
-   ],
-   "thresholds": [],
-   "timeFrom": null,
-   "timeRegions": [],
-   "timeShift": null,
-   "title": "ARC - Hit %",
-   "tooltip": {
-    "shared": true,
-    "sort": 2,
-    "value_type": "individual"
-   },
-   "type": "graph",
-   "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": []
-   },
-   "yaxes": [
-    {
-     "format": "percent",
-     "label": "",
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    },
-    {
-     "format": "short",
-     "label": null,
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    }
-   ],
-   "yaxis": {
-    "align": false,
-    "alignLevel": null
-   }
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "prometheus",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
-  {
-   "aliasColors": {},
-   "bars": false,
-   "dashLength": 10,
-   "dashes": false,
-   "datasource": "prometheus",
-   "decimals": 0,
-   "fill": 1,
-   "fillGradient": 0,
-   "gridPos": {
-    "h": 6,
-    "w": 12,
-    "x": 12,
-    "y": 9
-   },
-   "id": 13,
-   "legend": {
-    "alignAsTable": false,
-    "avg": false,
-    "current": false,
-    "max": false,
-    "min": false,
-    "rightSide": false,
-    "show": true,
-    "sideWidth": 350,
-    "total": true,
-    "values": true
-   },
-   "lines": true,
-   "linewidth": 1,
-   "links": [],
-   "nullPointMode": "null",
-   "options": {
-    "dataLinks": []
-   },
-   "percentage": false,
-   "pointradius": 5,
-   "points": false,
-   "renderer": "flot",
-   "seriesOverrides": [],
-   "spaceLength": 10,
-   "stack": false,
-   "steppedLine": false,
-   "targets": [
+  "description": "Graphs ZFS ARC and ARC L2 Hit %, Hits, Misses, Size, and Zpool",
+  "editable": true,
+  "gnetId": 7845,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1574354030467,
+  "links": [],
+  "panels": [
     {
-     "expr": "irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m])",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "data_hits",
-     "refId": "A",
-     "step": 2,
-     "target": ""
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": 0,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 14,
+      "legend": {
+        "alignAsTable": false,
+        "avg": true,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_demand_data_misses{instance=~\"$node\"}[5m])) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "data",
+          "refId": "A",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_demand_metadata_misses{instance=~\"$node\"}[5m])) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "metadata",
+          "refId": "B",
+          "step": 2,
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ARC - Hit %",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-     "expr": "irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m])",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "metadata_hits",
-     "refId": "B",
-     "step": 2,
-     "target": ""
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": 0,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 13,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(node_zfs_arc_demand_data_hits{instance=~\"$node\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "data_hits",
+          "refId": "A",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "irate(node_zfs_arc_demand_metadata_hits{instance=~\"$node\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "metadata_hits",
+          "refId": "B",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "irate(node_zfs_arc_demand_data_misses{instance=~\"$node\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "data_misses",
+          "refId": "C",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "irate(node_zfs_arc_demand_metadata_misses{instance=~\"$node\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "metadata_misses",
+          "refId": "D",
+          "step": 2,
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ARC - Hits, Misses",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-     "expr": "irate(node_zfs_arc_demand_data_misses{instance=~\"$node\"}[5m])",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "data_misses",
-     "refId": "C",
-     "step": 2,
-     "target": ""
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 15,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_zfs_arc_data_size{instance=~\"$node\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "data",
+          "refId": "I",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "node_zfs_arc_metadata_size{instance=~\"$node\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "metadata",
+          "refId": "D",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "node_zfs_arc_anon_size{instance=~\"$node\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "anon",
+          "refId": "B",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "node_zfs_arc_hdr_size{instance=~\"$node\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "hdr",
+          "refId": "C",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "node_zfs_arc_other_size{instance=~\"$node\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "other",
+          "refId": "J",
+          "step": 2,
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ARC - Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-     "expr": "irate(node_zfs_arc_demand_metadata_misses{instance=~\"$node\"}[5m])",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "metadata_misses",
-     "refId": "D",
-     "step": 2,
-     "target": ""
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": 0,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_l2_misses{instance=~\"$node\"}[5m])) * 100",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "L2",
+          "refId": "A",
+          "step": 2,
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ARC L2 - Hit %",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": 0,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 17,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "hits",
+          "refId": "A",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "irate(node_zfs_arc_l2_misses{instance=~\"$node\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "misses",
+          "refId": "B",
+          "step": 2,
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ARC L2 - Hits, Misses",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 18,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "node_zfs_arc_l2_asize{instance=~\"$node\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "asize",
+          "refId": "I",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "node_zfs_arc_l2_hdr_size{instance=~\"$node\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "metadata",
+          "refId": "D",
+          "step": 2,
+          "target": ""
+        },
+        {
+          "expr": "node_zfs_arc_l2_size{instance=~\"$node\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "size",
+          "refId": "B",
+          "step": 2,
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ARC L2 - Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
-   ],
-   "thresholds": [],
-   "timeFrom": null,
-   "timeRegions": [],
-   "timeShift": null,
-   "title": "ARC - Hits, Misses",
-   "tooltip": {
-    "shared": true,
-    "sort": 2,
-    "value_type": "individual"
-   },
-   "type": "graph",
-   "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": []
-   },
-   "yaxes": [
-    {
-     "format": "none",
-     "label": "",
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    },
-    {
-     "format": "short",
-     "label": null,
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    }
-   ],
-   "yaxis": {
-    "align": false,
-    "alignLevel": null
-   }
-  },
-  {
-   "aliasColors": {},
-   "bars": false,
-   "dashLength": 10,
-   "dashes": false,
-   "datasource": "prometheus",
-   "fill": 1,
-   "fillGradient": 0,
-   "gridPos": {
-    "h": 7,
-    "w": 24,
-    "x": 0,
-    "y": 15
-   },
-   "id": 15,
-   "legend": {
-    "alignAsTable": true,
-    "avg": true,
-    "current": true,
-    "max": true,
-    "min": true,
-    "rightSide": true,
-    "show": true,
-    "sideWidth": 350,
-    "total": false,
-    "values": true
-   },
-   "lines": true,
-   "linewidth": 1,
-   "links": [],
-   "nullPointMode": "null",
-   "options": {
-    "dataLinks": []
-   },
-   "percentage": false,
-   "pointradius": 5,
-   "points": false,
-   "renderer": "flot",
-   "seriesOverrides": [],
-   "spaceLength": 10,
-   "stack": true,
-   "steppedLine": false,
-   "targets": [
-    {
-     "expr": "node_zfs_arc_data_size{instance=~\"$node\"}",
-     "format": "time_series",
-     "hide": false,
-     "interval": "",
-     "intervalFactor": 2,
-     "legendFormat": "data",
-     "refId": "I",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "node_zfs_arc_metadata_size{instance=~\"$node\"}",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "metadata",
-     "refId": "D",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "node_zfs_arc_anon_size{instance=~\"$node\"}",
-     "format": "time_series",
-     "hide": false,
-     "interval": "",
-     "intervalFactor": 2,
-     "legendFormat": "anon",
-     "refId": "B",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "node_zfs_arc_hdr_size{instance=~\"$node\"}",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "hdr",
-     "refId": "C",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "node_zfs_arc_other_size{instance=~\"$node\"}",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "other",
-     "refId": "J",
-     "step": 2,
-     "target": ""
-    }
-   ],
-   "thresholds": [],
-   "timeFrom": null,
-   "timeRegions": [],
-   "timeShift": null,
-   "title": "ARC - Size",
-   "tooltip": {
-    "shared": true,
-    "sort": 2,
-    "value_type": "individual"
-   },
-   "type": "graph",
-   "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": []
-   },
-   "yaxes": [
-    {
-     "format": "bytes",
-     "label": "",
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    },
-    {
-     "format": "short",
-     "label": null,
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    }
-   ],
-   "yaxis": {
-    "align": false,
-    "alignLevel": null
-   }
-  },
-  {
-   "aliasColors": {},
-   "bars": false,
-   "dashLength": 10,
-   "dashes": false,
-   "datasource": "prometheus",
-   "decimals": 0,
-   "fill": 1,
-   "fillGradient": 0,
-   "gridPos": {
-    "h": 7,
-    "w": 12,
-    "x": 0,
-    "y": 23
-   },
-   "id": 16,
-   "legend": {
-    "alignAsTable": true,
-    "avg": true,
-    "current": false,
-    "hideEmpty": false,
-    "hideZero": false,
-    "max": false,
-    "min": false,
-    "rightSide": true,
-    "show": true,
-    "sideWidth": 350,
-    "total": false,
-    "values": true
-   },
-   "lines": true,
-   "linewidth": 1,
-   "links": [],
-   "nullPointMode": "null",
-   "options": {
-    "dataLinks": []
-   },
-   "percentage": false,
-   "pointradius": 5,
-   "points": false,
-   "renderer": "flot",
-   "seriesOverrides": [],
-   "spaceLength": 10,
-   "stack": false,
-   "steppedLine": false,
-   "targets": [
-    {
-     "expr": "irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m]) / (irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m]) + irate(node_zfs_arc_l2_misses{instance=~\"$node\"}[5m])) * 100",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "L2",
-     "refId": "A",
-     "step": 2,
-     "target": ""
-    }
-   ],
-   "thresholds": [],
-   "timeFrom": null,
-   "timeRegions": [],
-   "timeShift": null,
-   "title": "ARC L2 - Hit %",
-   "tooltip": {
-    "shared": true,
-    "sort": 2,
-    "value_type": "individual"
-   },
-   "type": "graph",
-   "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": []
-   },
-   "yaxes": [
-    {
-     "format": "percent",
-     "label": "",
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    },
-    {
-     "format": "short",
-     "label": null,
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    }
-   ],
-   "yaxis": {
-    "align": false,
-    "alignLevel": null
-   }
-  },
-  {
-   "aliasColors": {},
-   "bars": false,
-   "dashLength": 10,
-   "dashes": false,
-   "datasource": "prometheus",
-   "decimals": 0,
-   "fill": 1,
-   "fillGradient": 0,
-   "gridPos": {
-    "h": 7,
-    "w": 12,
-    "x": 12,
-    "y": 23
-   },
-   "id": 17,
-   "legend": {
-    "alignAsTable": true,
-    "avg": false,
-    "current": false,
-    "max": false,
-    "min": false,
-    "rightSide": true,
-    "show": true,
-    "sideWidth": 350,
-    "total": true,
-    "values": true
-   },
-   "lines": true,
-   "linewidth": 1,
-   "links": [],
-   "nullPointMode": "null",
-   "options": {
-    "dataLinks": []
-   },
-   "percentage": false,
-   "pointradius": 5,
-   "points": false,
-   "renderer": "flot",
-   "seriesOverrides": [],
-   "spaceLength": 10,
-   "stack": false,
-   "steppedLine": false,
-   "targets": [
-    {
-     "expr": "irate(node_zfs_arc_l2_hits{instance=~\"$node\"}[5m])",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "hits",
-     "refId": "A",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "irate(node_zfs_arc_l2_misses{instance=~\"$node\"}[5m])",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "misses",
-     "refId": "B",
-     "step": 2,
-     "target": ""
-    }
-   ],
-   "thresholds": [],
-   "timeFrom": null,
-   "timeRegions": [],
-   "timeShift": null,
-   "title": "ARC L2 - Hits, Misses",
-   "tooltip": {
-    "shared": true,
-    "sort": 2,
-    "value_type": "individual"
-   },
-   "type": "graph",
-   "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": []
-   },
-   "yaxes": [
-    {
-     "format": "none",
-     "label": "",
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    },
-    {
-     "format": "short",
-     "label": null,
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    }
-   ],
-   "yaxis": {
-    "align": false,
-    "alignLevel": null
-   }
-  },
-  {
-   "aliasColors": {},
-   "bars": false,
-   "dashLength": 10,
-   "dashes": false,
-   "datasource": "prometheus",
-   "fill": 1,
-   "fillGradient": 0,
-   "gridPos": {
-    "h": 7,
-    "w": 24,
-    "x": 0,
-    "y": 30
-   },
-   "id": 18,
-   "legend": {
-    "alignAsTable": true,
-    "avg": true,
-    "current": false,
-    "max": true,
-    "min": true,
-    "rightSide": true,
-    "show": true,
-    "sideWidth": 350,
-    "total": false,
-    "values": true
-   },
-   "lines": true,
-   "linewidth": 1,
-   "links": [],
-   "nullPointMode": "null",
-   "options": {
-    "dataLinks": []
-   },
-   "percentage": false,
-   "pointradius": 5,
-   "points": false,
-   "renderer": "flot",
-   "seriesOverrides": [],
-   "spaceLength": 10,
-   "stack": true,
-   "steppedLine": false,
-   "targets": [
-    {
-     "expr": "node_zfs_arc_l2_asize{instance=~\"$node\"}",
-     "format": "time_series",
-     "hide": false,
-     "interval": "",
-     "intervalFactor": 2,
-     "legendFormat": "asize",
-     "refId": "I",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "node_zfs_arc_l2_hdr_size{instance=~\"$node\"}",
-     "format": "time_series",
-     "intervalFactor": 2,
-     "legendFormat": "metadata",
-     "refId": "D",
-     "step": 2,
-     "target": ""
-    },
-    {
-     "expr": "node_zfs_arc_l2_size{instance=~\"$node\"}",
-     "format": "time_series",
-     "hide": false,
-     "interval": "",
-     "intervalFactor": 2,
-     "legendFormat": "size",
-     "refId": "B",
-     "step": 2,
-     "target": ""
-    }
-   ],
-   "thresholds": [],
-   "timeFrom": null,
-   "timeRegions": [],
-   "timeShift": null,
-   "title": "ARC L2 - Size",
-   "tooltip": {
-    "shared": true,
-    "sort": 2,
-    "value_type": "individual"
-   },
-   "type": "graph",
-   "xaxis": {
-    "buckets": null,
-    "mode": "time",
-    "name": null,
-    "show": true,
-    "values": []
-   },
-   "yaxes": [
-    {
-     "format": "bytes",
-     "label": "",
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    },
-    {
-     "format": "short",
-     "label": null,
-     "logBase": 1,
-     "max": null,
-     "min": null,
-     "show": true
-    }
-   ],
-   "yaxis": {
-    "align": false,
-    "alignLevel": null
-   }
-  }
- ],
- "refresh": "10s",
- "schemaVersion": 20,
- "style": "dark",
- "tags": [],
- "templating": {
-  "list": [
-   {
-    "allValue": null,
-    "current": {},
-    "datasource": "prometheus",
-    "definition": "label_values(node_zfs_arc_size, instance)",
-    "hide": 0,
-    "includeAll": false,
-    "label": null,
-    "multi": false,
-    "name": "node",
-    "options": [],
-    "query": "label_values(node_zfs_arc_size, instance)",
-    "refresh": 1,
-    "regex": "/([^:]+):.*/",
-    "skipUrlSync": false,
-    "sort": 1,
-    "tagValuesQuery": "",
-    "tags": [],
-    "tagsQuery": "",
-    "type": "query",
-    "useTags": false
-   }
-  ]
- },
- "time": {
-  "from": "now-30m",
-  "to": "now"
- },
- "timepicker": {
-  "refresh_intervals": [
-   "5s",
-   "10s",
-   "30s",
-   "1m",
-   "5m",
-   "15m",
-   "30m",
-   "1h",
-   "2h",
-   "1d"
   ],
-  "time_options": [
-   "5m",
-   "15m",
-   "1h",
-   "6h",
-   "12h",
-   "24h",
-   "2d",
-   "7d",
-   "30d"
-  ]
- },
- "timezone": "browser",
- "title": "ZFS ARC",
- "uid": "zfs-arc",
- "version": 1
+  "refresh": "10s",
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "definition": "label_values(node_zfs_arc_size, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": "label_values(node_zfs_arc_size, instance)",
+        "refresh": 1,
+        "regex": "/([^:]+):.*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "browser",
+  "title": "ZFS ARC",
+  "uid": "zfs-arc",
+  "version": 1
 }

--- a/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-pools.json
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-pools.json
@@ -1,393 +1,384 @@
 {
- "uid": "zfs-pools",
- "title": "ZFS Pools",
- "tags": [
-  "zfs",
-  "shodan"
- ],
- "timezone": "browser",
- "schemaVersion": 39,
- "refresh": "1m",
- "time": {
-  "from": "now-24h",
-  "to": "now"
- },
- "templating": {
-  "list": []
- },
- "panels": [
-  {
-   "type": "stat",
-   "title": "Pool health",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "gridPos": {
-    "h": 5,
-    "w": 8,
-    "x": 0,
-    "y": 0
-   },
-   "fieldConfig": {
-    "defaults": {
-     "mappings": [
-      {
-       "type": "value",
-       "options": {
-        "0": {
-         "text": "ONLINE",
-         "color": "green",
-         "index": 0
-        },
-        "1": {
-         "text": "DEGRADED",
-         "color": "orange",
-         "index": 1
-        },
-        "2": {
-         "text": "FAULTED",
-         "color": "red",
-         "index": 2
-        },
-        "3": {
-         "text": "OFFLINE",
-         "color": "red",
-         "index": 3
-        },
-        "4": {
-         "text": "UNAVAIL",
-         "color": "red",
-         "index": 4
-        },
-        "5": {
-         "text": "REMOVED",
-         "color": "red",
-         "index": 5
-        },
-        "6": {
-         "text": "SUSPENDED",
-         "color": "red",
-         "index": 6
-        }
-       }
-      }
-     ],
-     "color": {
-      "mode": "thresholds"
-     },
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "textMode": "value_and_name",
-    "colorMode": "background",
-    "graphMode": "none",
-    "justifyMode": "center",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "values": false
-    }
-   },
-   "targets": [
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "prometheus"
-     },
-     "expr": "zfs_pool_health",
-     "legendFormat": "{{pool}}",
-     "instant": true,
-     "refId": "A"
-    }
-   ]
+  "uid": "zfs-pools",
+  "title": "ZFS Pools",
+  "tags": ["zfs", "shodan"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "1m",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
   },
-  {
-   "type": "bargauge",
-   "title": "Capacity used",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "gridPos": {
-    "h": 5,
-    "w": 8,
-    "x": 8,
-    "y": 0
-   },
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percentunit",
-     "min": 0,
-     "max": 1,
-     "thresholds": {
-      "mode": "absolute",
-      "steps": [
-       {
-        "color": "green",
-        "value": null
-       },
-       {
-        "color": "yellow",
-        "value": 0.75
-       },
-       {
-        "color": "orange",
-        "value": 0.85
-       },
-       {
-        "color": "red",
-        "value": 0.95
-       }
-      ]
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "displayMode": "gradient",
-    "orientation": "horizontal",
-    "showUnfilled": true,
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "values": false
-    }
-   },
-   "targets": [
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "prometheus"
-     },
-     "expr": "zfs_pool_allocated_bytes / zfs_pool_size_bytes",
-     "legendFormat": "{{pool}}",
-     "instant": true,
-     "refId": "A"
-    }
-   ]
+  "templating": {
+    "list": []
   },
-  {
-   "type": "stat",
-   "title": "Free space",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "gridPos": {
-    "h": 5,
-    "w": 8,
-    "x": 16,
-    "y": 0
-   },
-   "fieldConfig": {
-    "defaults": {
-     "unit": "bytes",
-     "color": {
-      "mode": "fixed",
-      "fixedColor": "text"
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "textMode": "value_and_name",
-    "colorMode": "none",
-    "graphMode": "none",
-    "justifyMode": "center",
-    "reduceOptions": {
-     "calcs": [
-      "lastNotNull"
-     ],
-     "values": false
-    }
-   },
-   "targets": [
+  "panels": [
     {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "prometheus"
-     },
-     "expr": "zfs_pool_free_bytes",
-     "legendFormat": "{{pool}}",
-     "instant": true,
-     "refId": "A"
-    }
-   ]
-  },
-  {
-   "type": "timeseries",
-   "title": "Space used",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 0,
-    "y": 5
-   },
-   "fieldConfig": {
-    "defaults": {
-     "unit": "bytes",
-     "min": 0,
-     "custom": {
-      "lineWidth": 2,
-      "fillOpacity": 8,
-      "showPoints": "never",
-      "spanNulls": true
-     },
-     "color": {
-      "mode": "palette-classic"
-     }
-    },
-    "overrides": []
-   },
-   "options": {
-    "tooltip": {
-     "mode": "multi",
-     "sort": "desc"
-    },
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true
-    }
-   },
-   "targets": [
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "prometheus"
-     },
-     "expr": "zfs_pool_allocated_bytes",
-     "legendFormat": "{{pool}}",
-     "refId": "A"
-    }
-   ]
-  },
-  {
-   "type": "timeseries",
-   "title": "Fragmentation",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "gridPos": {
-    "h": 8,
-    "w": 12,
-    "x": 12,
-    "y": 5
-   },
-   "fieldConfig": {
-    "defaults": {
-     "unit": "percentunit",
-     "min": 0,
-     "custom": {
-      "lineWidth": 2,
-      "fillOpacity": 8,
-      "showPoints": "never",
-      "spanNulls": true
-     },
-     "color": {
-      "mode": "palette-classic"
-     },
-     "max": 1
-    },
-    "overrides": []
-   },
-   "options": {
-    "tooltip": {
-     "mode": "multi",
-     "sort": "desc"
-    },
-    "legend": {
-     "displayMode": "list",
-     "placement": "bottom",
-     "showLegend": true
-    }
-   },
-   "targets": [
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "prometheus"
-     },
-     "expr": "zfs_pool_fragmentation_ratio",
-     "legendFormat": "{{pool}}",
-     "refId": "A"
-    }
-   ]
-  },
-  {
-   "type": "table",
-   "title": "Top datasets by space used",
-   "datasource": {
-    "type": "prometheus",
-    "uid": "prometheus"
-   },
-   "gridPos": {
-    "h": 9,
-    "w": 24,
-    "x": 0,
-    "y": 13
-   },
-   "fieldConfig": {
-    "defaults": {
-     "unit": "bytes"
-    },
-    "overrides": []
-   },
-   "options": {
-    "sortBy": [
-     {
-      "displayName": "Value",
-      "desc": true
-     }
-    ]
-   },
-   "targets": [
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "prometheus"
-     },
-     "expr": "topk(20, zfs_dataset_used_bytes{type=~\"filesystem|volume\"})",
-     "format": "table",
-     "instant": true,
-     "refId": "A"
-    }
-   ],
-   "transformations": [
-    {
-     "id": "organize",
-     "options": {
-      "excludeByName": {
-       "Time": true,
-       "__name__": true,
-       "job": true,
-       "instance": true
+      "type": "stat",
+      "title": "Pool health",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
       },
-      "renameByName": {
-       "name": "dataset",
-       "Value": "used"
-      }
-     }
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "ONLINE",
+                  "color": "green",
+                  "index": 0
+                },
+                "1": {
+                  "text": "DEGRADED",
+                  "color": "orange",
+                  "index": 1
+                },
+                "2": {
+                  "text": "FAULTED",
+                  "color": "red",
+                  "index": 2
+                },
+                "3": {
+                  "text": "OFFLINE",
+                  "color": "red",
+                  "index": 3
+                },
+                "4": {
+                  "text": "UNAVAIL",
+                  "color": "red",
+                  "index": 4
+                },
+                "5": {
+                  "text": "REMOVED",
+                  "color": "red",
+                  "index": 5
+                },
+                "6": {
+                  "text": "SUSPENDED",
+                  "color": "red",
+                  "index": 6
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "textMode": "value_and_name",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "zfs_pool_health",
+          "legendFormat": "{{pool}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "Capacity used",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "orange",
+                "value": 0.85
+              },
+              {
+                "color": "red",
+                "value": 0.95
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true,
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "zfs_pool_allocated_bytes / zfs_pool_size_bytes",
+          "legendFormat": "{{pool}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Free space",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "textMode": "value_and_name",
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "zfs_pool_free_bytes",
+          "legendFormat": "{{pool}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Space used",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "zfs_pool_allocated_bytes",
+          "legendFormat": "{{pool}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Fragmentation",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "zfs_pool_fragmentation_ratio",
+          "legendFormat": "{{pool}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Top datasets by space used",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(20, zfs_dataset_used_bytes{type=~\"filesystem|volume\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "renameByName": {
+              "name": "dataset",
+              "Value": "used"
+            }
+          }
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-pools.json
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/dashboards/zfs-pools.json
@@ -1,0 +1,393 @@
+{
+ "uid": "zfs-pools",
+ "title": "ZFS Pools",
+ "tags": [
+  "zfs",
+  "shodan"
+ ],
+ "timezone": "browser",
+ "schemaVersion": 39,
+ "refresh": "1m",
+ "time": {
+  "from": "now-24h",
+  "to": "now"
+ },
+ "templating": {
+  "list": []
+ },
+ "panels": [
+  {
+   "type": "stat",
+   "title": "Pool health",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "gridPos": {
+    "h": 5,
+    "w": 8,
+    "x": 0,
+    "y": 0
+   },
+   "fieldConfig": {
+    "defaults": {
+     "mappings": [
+      {
+       "type": "value",
+       "options": {
+        "0": {
+         "text": "ONLINE",
+         "color": "green",
+         "index": 0
+        },
+        "1": {
+         "text": "DEGRADED",
+         "color": "orange",
+         "index": 1
+        },
+        "2": {
+         "text": "FAULTED",
+         "color": "red",
+         "index": 2
+        },
+        "3": {
+         "text": "OFFLINE",
+         "color": "red",
+         "index": 3
+        },
+        "4": {
+         "text": "UNAVAIL",
+         "color": "red",
+         "index": 4
+        },
+        "5": {
+         "text": "REMOVED",
+         "color": "red",
+         "index": 5
+        },
+        "6": {
+         "text": "SUSPENDED",
+         "color": "red",
+         "index": 6
+        }
+       }
+      }
+     ],
+     "color": {
+      "mode": "thresholds"
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       }
+      ]
+     }
+    },
+    "overrides": []
+   },
+   "options": {
+    "textMode": "value_and_name",
+    "colorMode": "background",
+    "graphMode": "none",
+    "justifyMode": "center",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "values": false
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "expr": "zfs_pool_health",
+     "legendFormat": "{{pool}}",
+     "instant": true,
+     "refId": "A"
+    }
+   ]
+  },
+  {
+   "type": "bargauge",
+   "title": "Capacity used",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "gridPos": {
+    "h": 5,
+    "w": 8,
+    "x": 8,
+    "y": 0
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "percentunit",
+     "min": 0,
+     "max": 1,
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "yellow",
+        "value": 0.75
+       },
+       {
+        "color": "orange",
+        "value": 0.85
+       },
+       {
+        "color": "red",
+        "value": 0.95
+       }
+      ]
+     }
+    },
+    "overrides": []
+   },
+   "options": {
+    "displayMode": "gradient",
+    "orientation": "horizontal",
+    "showUnfilled": true,
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "values": false
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "expr": "zfs_pool_allocated_bytes / zfs_pool_size_bytes",
+     "legendFormat": "{{pool}}",
+     "instant": true,
+     "refId": "A"
+    }
+   ]
+  },
+  {
+   "type": "stat",
+   "title": "Free space",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "gridPos": {
+    "h": 5,
+    "w": 8,
+    "x": 16,
+    "y": 0
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes",
+     "color": {
+      "mode": "fixed",
+      "fixedColor": "text"
+     }
+    },
+    "overrides": []
+   },
+   "options": {
+    "textMode": "value_and_name",
+    "colorMode": "none",
+    "graphMode": "none",
+    "justifyMode": "center",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "values": false
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "expr": "zfs_pool_free_bytes",
+     "legendFormat": "{{pool}}",
+     "instant": true,
+     "refId": "A"
+    }
+   ]
+  },
+  {
+   "type": "timeseries",
+   "title": "Space used",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 5
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes",
+     "min": 0,
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 8,
+      "showPoints": "never",
+      "spanNulls": true
+     },
+     "color": {
+      "mode": "palette-classic"
+     }
+    },
+    "overrides": []
+   },
+   "options": {
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    },
+    "legend": {
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "expr": "zfs_pool_allocated_bytes",
+     "legendFormat": "{{pool}}",
+     "refId": "A"
+    }
+   ]
+  },
+  {
+   "type": "timeseries",
+   "title": "Fragmentation",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 5
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "percentunit",
+     "min": 0,
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 8,
+      "showPoints": "never",
+      "spanNulls": true
+     },
+     "color": {
+      "mode": "palette-classic"
+     },
+     "max": 1
+    },
+    "overrides": []
+   },
+   "options": {
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    },
+    "legend": {
+     "displayMode": "list",
+     "placement": "bottom",
+     "showLegend": true
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "expr": "zfs_pool_fragmentation_ratio",
+     "legendFormat": "{{pool}}",
+     "refId": "A"
+    }
+   ]
+  },
+  {
+   "type": "table",
+   "title": "Top datasets by space used",
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "gridPos": {
+    "h": 9,
+    "w": 24,
+    "x": 0,
+    "y": 13
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "bytes"
+    },
+    "overrides": []
+   },
+   "options": {
+    "sortBy": [
+     {
+      "displayName": "Value",
+      "desc": true
+     }
+    ]
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "prometheus"
+     },
+     "expr": "topk(20, zfs_dataset_used_bytes{type=~\"filesystem|volume\"})",
+     "format": "table",
+     "instant": true,
+     "refId": "A"
+    }
+   ],
+   "transformations": [
+    {
+     "id": "organize",
+     "options": {
+      "excludeByName": {
+       "Time": true,
+       "__name__": true,
+       "job": true,
+       "instance": true
+      },
+      "renameByName": {
+       "name": "dataset",
+       "Value": "used"
+      }
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -270,6 +270,14 @@ spec:
                 target_label: __param_target
               - target_label: __address__
                 replacement: ${NFS_SERVER}:9221
+          # zfs_exporter: pool health/capacity + dataset usage via the zfs
+          # CLIs — invisible to node_exporter's kstat-based zfs collector.
+          - job_name: zfs-shodan
+            static_configs:
+              - targets:
+                  - ${NFS_SERVER}:9134
+                labels:
+                  instance: shodan
         # retentionSize is the real safety valve on a fixed-size disk: Prometheus
         # GCs by size before it can ever hit ENOSPC (a full 10Gi SSD PVC wedged
         # the TSDB 2026-06-20 → blind 5d). Keep it comfortably under the PVC size.

--- a/cluster/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -2,3 +2,19 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - prometheus-rule.yaml
+# Vendored Grafana dashboards, loaded by the sidecar via the
+# grafana_dashboard label. Vendored (vs gnetId) because these need local
+# edits: zfs-arc is upstream 7845 patched for our job/instance labels with
+# the OpenZFS-2.x-dead pool-IO panels removed; zfs-pools is purpose-built
+# for pdf/zfs_exporter metric names.
+configMapGenerator:
+  - name: grafana-dashboards-zfs
+    namespace: monitoring
+    files:
+      - dashboards/zfs-arc.json
+      - dashboards/zfs-pools.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+      disableNameSuffixHash: true

--- a/cluster/apps/monitoring/kube-prometheus-stack/app/prometheus-rule.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/prometheus-rule.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: zfs-pools
+  namespace: monitoring
+spec:
+  groups:
+    - name: zfs.pools
+      rules:
+        # zfs_pool_health enum (pdf/zfs_exporter): 0 ONLINE, 1 DEGRADED,
+        # 2 FAULTED, 3 OFFLINE, 4 UNAVAIL, 5 REMOVED, 6 SUSPENDED.
+        - alert: ZFSPoolUnhealthy
+          annotations:
+            summary: "ZFS pool {{ $labels.pool }} is not ONLINE"
+            description: >-
+              Pool {{ $labels.pool }} on {{ $labels.instance }} reports health
+              code {{ $value }} (1=DEGRADED 2=FAULTED 3=OFFLINE 4=UNAVAIL
+              5=REMOVED 6=SUSPENDED). Check `zpool status {{ $labels.pool }}`.
+          expr: |
+            max by (pool, instance) (zfs_pool_health) > 0
+          for: 5m
+          labels:
+            severity: critical
+        # ZFS allocation/perf degrades as pools fill; 85% is the "plan a
+        # cleanup" line, 95% is the "act now" line.
+        - alert: ZFSPoolCapacityHigh
+          annotations:
+            summary: "ZFS pool {{ $labels.pool }} over 85% full"
+            description: >-
+              Pool {{ $labels.pool }} on {{ $labels.instance }} is
+              {{ $value | humanizePercentage }} full (warning threshold 85%).
+          expr: |
+            max by (pool, instance) (zfs_pool_allocated_bytes / zfs_pool_size_bytes) > 0.85
+          for: 1h
+          labels:
+            severity: warning
+        - alert: ZFSPoolCapacityCritical
+          annotations:
+            summary: "ZFS pool {{ $labels.pool }} over 95% full"
+            description: >-
+              Pool {{ $labels.pool }} on {{ $labels.instance }} is
+              {{ $value | humanizePercentage }} full (critical threshold 95%).
+          expr: |
+            max by (pool, instance) (zfs_pool_allocated_bytes / zfs_pool_size_bytes) > 0.95
+          for: 15m
+          labels:
+            severity: critical


### PR DESCRIPTION
## Summary
Companion to home_infra `82277be` (zfs_exporter deployed on shodan, verified serving 559 series on :9134).

- **Scrape job** `zfs-shodan` → `${NFS_SERVER}:9134` (`instance=shodan`), same static-config pattern as the other shodan jobs
- **Dashboards** — vendored as a labeled ConfigMap (sidecar) instead of `gnetId` because both need local edits:
  - `zfs-arc`: upstream 7845 patched for our labels (upstream hardcodes `job="node-exporter"` and `host:port` instances) with its pool-IO panels dropped — OpenZFS 2.x removed the per-pool io kstat they query, so they'd be permanently empty
  - `zfs-pools`: purpose-built against live pdf/zfs_exporter metrics — health stat with ONLINE/DEGRADED/… value mappings (state readable as text, not color-alone), capacity bar gauge (75/85/95% thresholds), free space, used + fragmentation trends, top-20 datasets table
- **Alerts** (`PrometheusRule zfs-pools`): `ZFSPoolUnhealthy` (any pool health ≠ ONLINE for 5m, critical), `ZFSPoolCapacityHigh` (>85% for 1h, warning), `ZFSPoolCapacityCritical` (>95% for 15m, critical)

## Test plan
- [x] `kubectl kustomize` builds clean; dashboard JSONs validate
- [x] Exporter verified live: all three pools (rpool/tank/dumpster) ONLINE, health enum confirmed from exporter HELP text
- [ ] After merge: `zfs-shodan` target up, both dashboards render with data, `ZFSPool*` rules visible in Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GySFiuZLDE8fKS7eDTRriJ