### PR TITLE
monitoring: route Watchdog to external dead-man receiver (Kuma push)

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -44,13 +44,24 @@ spec:
           repeat_interval: 12h
           receiver: "null"
           routes:
+            # Watchdog is the always-firing dead-man's-switch: it must reach an
+            # ALERT-ON-SILENCE monitor outside this stack (Uptime Kuma push
+            # monitor). If these heartbeats stop, Prometheus/alertmanager is
+            # down — the one failure Slack can never report.
             - match:
                 alertname: Watchdog
-              receiver: "null"
+              receiver: "deadman"
+              group_wait: 0s
+              group_interval: 1m
+              repeat_interval: 1m
             - receiver: "slack-notifications"
               continue: true
         receivers:
           - name: "null"
+          - name: "deadman"
+            webhook_configs:
+              - url: "${SECRET_ALERTMANAGER_DEADMAN_URL}"
+                send_resolved: false
           - name: "slack-notifications"
             slack_configs:
               - channel: "#prometheus"


### PR DESCRIPTION
Backup-audit finding F2: the always-firing `Watchdog` alert was routed to `"null"`, discarding the dead-man's-switch signal — which is why the 7-day Prometheus outage produced zero notifications. This routes it to a `deadman` webhook receiver (Uptime Kuma push monitor) at a 1-minute heartbeat.

**Before merging**: add `SECRET_ALERTMANAGER_DEADMAN_URL` (the Kuma push URL, e.g. `https://kuma.../api/push/<token>?status=up&msg=watchdog`) to `cluster/base/cluster-secrets.yaml`. If the var is missing, flux substitution leaves the literal `${...}` in the alertmanager config.

**Kuma side**: create a *push* monitor with heartbeat interval 60s and a grace period (suggest 5–15 min) so restarts don't page.

Note for the record: Kuma runs in-cluster (monitoring ns, node-attached PVC), so a full-cluster or node2 outage still takes the watcher down with the watched — this closes the Prometheus-death case, not the cluster-death case. An external check (healthchecks.io) pointed at Kuma's own status page would close the loop fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UevnaSpNqfC3Y2Ye5SxyLB