### PR TITLE
traefik: chart v41 with values migration + CRD upgrade policy

### DIFF
--- a/cluster/apps/ingress/traefik-internal/app/helm-release.yaml
+++ b/cluster/apps/ingress/traefik-internal/app/helm-release.yaml
@@ -6,10 +6,14 @@ metadata:
   namespace: ingress
 spec:
   interval: 5m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
   chart:
     spec:
       chart: traefik
-      version: 40.3.0
+      version: 41.0.1
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -86,11 +90,11 @@ spec:
         defaultCertificate:
           secretName: "${SECRET_DOMAIN/./-}-tls"
 
-    logs:
-      general:
-        level: INFO
-      access:
-        enabled: false
+    # v41 renamed logs.general -> log and logs.access -> accessLog
+    log:
+      level: INFO
+    accessLog:
+      enabled: false
 
     metrics:
       prometheus:

--- a/cluster/apps/ingress/traefik/app/helm-release.yaml
+++ b/cluster/apps/ingress/traefik/app/helm-release.yaml
@@ -6,10 +6,14 @@ metadata:
   namespace: ingress
 spec:
   interval: 5m
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
   chart:
     spec:
       chart: traefik
-      version: 40.3.0
+      version: 41.0.1
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -131,11 +135,11 @@ spec:
       - "--entrypoints.websecure.http.middlewares="
       - "--providers.kubernetesingress.allowEmptyServices=true"
 
-    logs:
-      general:
-        level: INFO
-      access:
-        enabled: false
+    # v41 renamed logs.general -> log and logs.access -> accessLog
+    log:
+      level: INFO
+    accessLog:
+      enabled: false
 
     metrics:
       prometheus:


### PR DESCRIPTION
Hand-rolled replacement for renovate #1570, which would have broken on v41's values renames (`logs.general`→`log`, `logs.access`→`accessLog`) used by both instances. Both releases dry-render clean against 41.0.1 (traefik v3.7.5): `--log.level=INFO` present, accesslog off, nebula sidecar intact. Also adds `crds: Create/CreateReplace` so traefik CRD updates stop being silently skipped by flux's default policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UevnaSpNqfC3Y2Ye5SxyLB