### PR TITLE
kured: chart v6 (validated values-compatible)

### DIFF
--- a/cluster/apps/kube-system/kured/app/helm-release.yaml
+++ b/cluster/apps/kube-system/kured/app/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://kubereboot.github.io/charts
       chart: kured
-      version: 5.12.1
+      version: 6.0.0
       sourceRef:
         kind: HelmRepository
         name: kubereboot-charts


### PR DESCRIPTION
Supersedes #1569. Render-tested with live values: all flags identical, ships kured 1.22.1.