### PR TITLE
retrosync: fix saves PV path

### DIFF
--- a/cluster/apps/retrosync/retrosync/app/saves-pvc.yaml
+++ b/cluster/apps/retrosync/retrosync/app/saves-pvc.yaml
@@ -17,7 +17,7 @@ spec:
     - nfsvers=4
     - port=2049
   nfs:
-    path: /tank/appdata/syncthing
+    path: /dumpster/backups/syncthing
     server: "${NFS_SERVER}"
   persistentVolumeReclaimPolicy: Retain
 ---


### PR DESCRIPTION
Verified against live config; previous path was the wrong share. 🤖 https://claude.ai/code/session_01UevnaSpNqfC3Y2Ye5SxyLB