### PR TITLE
external-secrets: 1Password SDK store + validation canary (phase 1, step 1)

### DIFF
--- a/cluster/apps/external-secrets/external-secrets/ks.yaml
+++ b/cluster/apps/external-secrets/external-secrets/ks.yaml
@@ -51,3 +51,21 @@ spec:
 #   retryInterval: 1m
 #   timeout: 5m
 
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-external-secrets-store-onepassword-sdk
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/apps/external-secrets/external-secrets/store/onepassword-sdk
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: cluster-apps-external-secrets

--- a/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/canary-externalsecret.yaml
+++ b/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/canary-externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# Canary: proves the SDK store end-to-end before the main store is flipped.
+# Mirrors an item the connect store already syncs elsewhere, so the produced
+# Secret can be diffed against known-good output. Delete after cutover.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: onepassword-sdk-canary
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-sdk
+  target:
+    name: onepassword-sdk-canary
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: cnpg-garage

--- a/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/clustersecretstore.yaml
+++ b/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/clustersecretstore.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-sdk
+  namespace: external-secrets
+spec:
+  provider:
+    onepasswordSDK:
+      vault: kubernetes
+      auth:
+        serviceAccountSecretRef:
+          name: onepassword-sdk-token
+          namespace: external-secrets
+          key: token
+      integrationInfo:
+        name: external-secrets
+        version: v1

--- a/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/kustomization.yaml
+++ b/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./clustersecretstore.yaml
+  - ./canary-externalsecret.yaml

--- a/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/secret.sops.yaml
+++ b/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/secret.sops.yaml
@@ -4,15 +4,15 @@ metadata:
     name: onepassword-sdk-token
     namespace: external-secrets
 stringData:
-    token: ENC[AES256_GCM,data:n3LNjqsSaeYELOsO7/kgBciZjrkJV3QR9VuWHtNWD+W9YuQTlA==,iv:oV4lpriwposJNifxw/umzvWU6GPSFsWFtXOQbYHbusg=,tag:hs8KgJrf2yiGlOJqyicr7w==,type:str]
+    token: ENC[AES256_GCM,data:x1OUHaufmw6isPR/L1r1Oh1xQbLS33SIJa3g6nCoDBuw4Xo3f/y4wStQJ+P2P3Q0OpoxNsp0NIPgmXIEcP8drga4YtmYP92ANvF5RsK59AzUr8q4pOSlbVqSnNz7O+ZMzHolLev4iZTU+OBJmLlFVJ+1xypv1AgVvF+NCxhcxahZCP/r8yrs0w5eldcheSkKeT+rxCP9yeGe2j7VzLKGAugB6n4HaFsgFW260SuyPAoBkDQQ5k5VoT/mQgzUz6Z5ibhSlFdRHj5ZMvU7dR/6AJG51S0UhmtgA247PoalNdvfHL21nPb/t+T2Iynm8GzwTPWcVBqcruv0L6awgu2lySEhNlBL6YncfgsxQ3DBFb6vfr1A4NwtlPQnzlid/zA9ZyRqt7HrCXnI5LsKF3gs5eZDGr8uKvo3vdC2km+/mK05wT2q1jjJpwyGAgEUqqoUs9Jq144vMmiMTQnE5MB37bPulT4eT7YY8UbSKadnCXa8kioLJh/aStXNk3yadSY0sVw12teIISYy1+pyIRlU1Y/afAbRlpcX22nFSXPJn2qMt7YvJGVN1g3655eqnKcBYKFpb21zzUnGFNwGZRe7F0B+eXYlH7ZT8HFXih6AK2Bz1TzikLpC0T0l3Gm6iweEkOsMTfyCwXz7w8LQZm7iNRf/PfjMnDcivQrF2UQRxKC7jUNpjbU8Z6Fjn03Ieqf8R441G6p+Pdd+Z1i7cBV+adqdWBeWM7kgJ2kJGAKxaN+OEDeymG9FzAS5cttTiy9zlRTKY/aMLll2m/c/DEc51zgbuk8PLujiR+lpC2Q6MqZ8RDnbZFzQ2aacDyp9M6X+BF0I4JfbO3Fz5IAvDJ9DZoiT,iv:pQVVqdrHcTL/UBJUG8/1W8oR1Z6Ja5ghI8f2HMPDC5U=,tag:1CUF7j880uqZplLIJ/kuyA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2026-07-06T19:05:46Z"
-    mac: ENC[AES256_GCM,data:2/wmZM/0Oy/uJqSlJdkR9u100t4wKnEv2qwTHn1BnEYZkwGVnHpDUnY0vvwE1YI/veTWOcxov6deMsMC+F8lznfWFHFqRZN4CRTWz9r6zVLfkUFQ1NUTHpvxHeAAIXScjI3ZRxPR8HO93wOtgO/80QL1uzE2bABPpn6tDwRxeMA=,iv:OZ+O/LLXZVsIM5I5X55ZanUbwjFfpgMv+ucKT4g+lgg=,tag:q1sKzRc6zEYiQTXbiga76Q==,type:str]
+    lastmodified: "2026-07-07T13:43:18Z"
+    mac: ENC[AES256_GCM,data:jjIIAHrZgCeHuOQ00FIF4AncDh5wAnefknIMKeI2CV1roAI3rhIzV5a7xWeHe+eLQp1Yhw9Bk7H3y3dBBUjE9Gu4du/l24ltwLXZ7r/HAM9JT18kjur7I8rLXl/urKW0Kt4tQaqXW546yNbAPGQcbUuL0yQAuI04KLu77nsq+/Y=,iv:X6aLXCqGQgzq3kPPHJA4VZGufuP7PVoVMDmF4jernJY=,tag:W6Yjxm2kRDo866XLi66qwQ==,type:str]
     pgp:
         - created_at: "2026-07-06T19:05:45Z"
           enc: |

--- a/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/secret.sops.yaml
+++ b/cluster/apps/external-secrets/external-secrets/store/onepassword-sdk/secret.sops.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: onepassword-sdk-token
+    namespace: external-secrets
+stringData:
+    token: ENC[AES256_GCM,data:n3LNjqsSaeYELOsO7/kgBciZjrkJV3QR9VuWHtNWD+W9YuQTlA==,iv:oV4lpriwposJNifxw/umzvWU6GPSFsWFtXOQbYHbusg=,tag:hs8KgJrf2yiGlOJqyicr7w==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-06T19:05:46Z"
+    mac: ENC[AES256_GCM,data:2/wmZM/0Oy/uJqSlJdkR9u100t4wKnEv2qwTHn1BnEYZkwGVnHpDUnY0vvwE1YI/veTWOcxov6deMsMC+F8lznfWFHFqRZN4CRTWz9r6zVLfkUFQ1NUTHpvxHeAAIXScjI3ZRxPR8HO93wOtgO/80QL1uzE2bABPpn6tDwRxeMA=,iv:OZ+O/LLXZVsIM5I5X55ZanUbwjFfpgMv+ucKT4g+lgg=,tag:q1sKzRc6zEYiQTXbiga76Q==,type:str]
+    pgp:
+        - created_at: "2026-07-06T19:05:45Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0dSZMvnEisuAQ/+JJfH9Z59inJVyF3zZ1lGlwIUbxIHhWbR5OjC9GntwnDf
+            c7Fgsmolagwbx6z/gg+/iF+jVA/au2MbSX+c8SkV2WRCv17VGp5+lYOB1DRq/+t7
+            MNZh4xEOqFyEEYXww7dGJBmYldkSTm0jkozbO9pagf5yIJYRhAldx/mC/fygbR66
+            j92kjRso+JAEsZonKUEf/AAw3MfOJcZCZcxBDXpPe0OpqZO8rOKnBf4hreaSJ8Pj
+            InMS2e6Nzmksxo7oT8JB/7HJ0ZLVYGd1VX+4ZpzSb4nUvi+IcLnrFb7cQ6PHeaRB
+            ro/Txvzgz8aHzs3r+hKoeMn/uyxoxW8q0ieY5yjSQKRTFH06mZ2jr6TVLf/hfhii
+            Z5sEEpowiRCuoHOFoQw3An2d2pXZi1srbpGlBYD9rsGPnOydZ0RsfBCKTNo8twpX
+            +O1SmlDOxUGUFjF6tQPMoAfpaj3rnN24ngqTR7zLoXOZ4quCOeTXPQVAv9CeGTkr
+            uX0l6piH2HYvWhcxSOqUQRg7whRdyb7r3FhDtAuEnAVgJDxJBYSP90RNozMJV2Cx
+            /EymC1K8K90pZzGKMkxxBA0q6iqAk4rR9Nr38KYGTIhe3qWGy17iytESn/zhpLEb
+            UXoNfGAadbkGaqykJP1QtU7EPhJ/rKZTmNE6vYLbrFkrD8AGHyhFYr5JLgcLiq/S
+            XgEkrKxic/zxSbt+ypW3DeCHZzuNaiYPEGiz43j8YKVDXikYa1k1Al9m/C6NTdSD
+            M5B4BkZ6ge7m5AjY7w8dDaBlb5Zx6JGk6qqLllBVQEs5FnZhQYgs+0OVTWPoCJM=
+            =r+bX
+            -----END PGP MESSAGE-----
+          fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
+        - created_at: "2026-07-06T19:05:45Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAxbwxdi5IniFARAAlLlKqUbAV9OJtMVD0aZK84bMAS3E8P2Qh0AO0sxseotJ
+            eoiPuL25jb75M+jrAblX9k8dWgievOnxZfeMUdVNjLU2lCTfSj4PTuorsPF8MKk5
+            pu5pxioKdP0QB4TAGcps9vDHXj6veLwd5DiXaB6wSRhQwKcYaDcs+d5D2o9cVgAI
+            ZU4w5vBOHcCuUhy/CFPeCvrTX+w6HIzruVncYQIYvfmIJPfy9qqOL/gNklRIAxSf
+            kGg+YWiofhN6gD8L8rfIPfwmW98EYeSx4fxs4Ni5ToHOS/xM2tBNPhleG5iFJK6l
+            Rsc+Na+5z9hcKSaOyMJ2S+hf89eN+dX8T1R/BTH5kzKtUkm4XVPMAkC8sEb68BAY
+            WT1A066WVvm5cJgeDE9d9F2Y7eWDSJ8N0OvPezWYI7aD6ZEiLIY1QeuKsKwZK9Jp
+            mG7CfaDS0bFmm9Ogws3tAzJE+aq6jLmrbsUm/Ln+fcPQzebDbkoiuJrgwmj2IYVM
+            eZ9MsVi2dcxyP5trtVfShRQDTGml9Qy4EzKqEFHqEYURSD8lXq3cHcYZMfMDtwCi
+            tbrSdL5dd1coSwt1k2W/W+uxzUdD7289BALxxh+uGJ3jbOVy3lRoHvIGMr67zb69
+            pFcmT6k6HMPY3LAmH+9f1VeRpvqSawFnATv22abJOVrKGyYgs6XpdIToV8b5KXLS
+            XgEPncnuBRzgcW2bzoalc09l2s/5SGBQAkI9pY19VxtBrvbkT/k6IqEez+0Bk/3l
+            QzH6MFAMlawARcxCFJ6/9a6WAIOcmrosL4DWp9Cuqnj8/ZtQU9TtiQytemO1M0w=
+            =o9z+
+            -----END PGP MESSAGE-----
+          fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1


### PR DESCRIPTION
First step of the secrets-consolidation phase 1 (design doc in the private repo). NOT ready to merge until:

1. A 1Password service account exists (read-only, `kubernetes` vault) — owner task
2. Its token replaces the placeholder: `sops edit .../store/onepassword-sdk/secret.sops.yaml`

Then merge → canary ExternalSecret `onepassword-sdk-canary` (ns external-secrets) should go Ready and its Secret should diff clean against the connect-produced equivalent. Main-store provider flip + Connect soak/removal follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UevnaSpNqfC3Y2Ye5SxyLB