### PR TITLE
renovate: close remaining tag blind spots

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -174,6 +174,16 @@
       versioning: 'regex:^(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>[a-f0-9]+)$',
     },
     {
+      description: 'Vane slim-prefixed tags (slim-vX.Y.Z) — prefix hides them from default versioning',
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'itzcrazykns1337/vane',
+      ],
+      versioning: 'regex:^slim-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+    },
+    {
       description: 'Use loose versioning for certain dependencies',
       matchDatasources: [
         'docker',

--- a/cluster/apps/mealie/mealie/app/helm-release.yaml
+++ b/cluster/apps/mealie/mealie/app/helm-release.yaml
@@ -39,7 +39,7 @@ spec:
           init-db:
             image:
               repository: ghcr.io/home-operations/postgres-init
-              tag: 18
+              tag: 18.4.0@sha256:ebd9d30add17acdf935d73eb004758c7dfd9388aaa605fda70ad74378ab92aec
             env:
               INIT_POSTGRES_DBNAME: mealie
               INIT_POSTGRES_HOST: mealiedb-rw


### PR DESCRIPTION
Completes the coverage audit: vane prefix rule + postgres-init proper pin. minio's RELEASE.* tag left alone (decommissioning). 🤖 https://claude.ai/code/session_01UevnaSpNqfC3Y2Ye5SxyLB