### PR TITLE
external-secrets: main store to SDK provider (phase 1 flip)

### DIFF
--- a/cluster/apps/external-secrets/external-secrets/store/onepassword/clustersecretstore.yaml
+++ b/cluster/apps/external-secrets/external-secrets/store/onepassword/clustersecretstore.yaml
@@ -1,4 +1,7 @@
 ---
+# Provider flipped connect -> SDK (store NAME kept so no ExternalSecret
+# changes needed). The connect deployment soaks until this proves out,
+# then ns 1password gets decommissioned.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
@@ -6,13 +9,13 @@ metadata:
   namespace: external-secrets
 spec:
   provider:
-    onepassword:
-      connectHost: http://onepassword-connect.1password.svc.cluster.local:8080
-      vaults:
-        kubernetes: 1
+    onepasswordSDK:
+      vault: kubernetes
       auth:
-        secretRef:
-          connectTokenSecretRef:
-            name: onepassword-connect-token
-            key: token
-            namespace: external-secrets
+        serviceAccountSecretRef:
+          name: onepassword-sdk-token
+          namespace: external-secrets
+          key: token
+      integrationInfo:
+        name: external-secrets
+        version: v1


### PR DESCRIPTION
Zero ExternalSecret changes — store name unchanged. Rollback = revert. 🤖 https://claude.ai/code/session_01UevnaSpNqfC3Y2Ye5SxyLB