### PR TITLE
netpol: fix hostNetwork client access across nodes

### DIFF
--- a/cluster/apps/ai/litellm/app/networkpolicy.yaml
+++ b/cluster/apps/ai/litellm/app/networkpolicy.yaml
@@ -81,3 +81,14 @@ spec:
     - from:
         - ipBlock:
             cidr: 172.16.1.0/24
+        # cross-node traffic from hostNetwork pods is sourced from the
+        # origin node's flannel.1/cni0 IPs (.0/.1 of its pod CIDR), not
+        # its LAN IP — pods themselves start at .2, so /31s stay tight
+        - ipBlock:
+            cidr: 10.42.0.0/31
+        - ipBlock:
+            cidr: 10.42.1.0/31
+        - ipBlock:
+            cidr: 10.42.3.0/31
+        - ipBlock:
+            cidr: 10.42.4.0/31

--- a/cluster/apps/home/hass/app/networkpolicy.yaml
+++ b/cluster/apps/home/hass/app/networkpolicy.yaml
@@ -61,3 +61,14 @@ spec:
     - from:
         - ipBlock:
             cidr: 172.16.1.0/24
+        # cross-node traffic from hostNetwork pods is sourced from the
+        # origin node's flannel.1/cni0 IPs (.0/.1 of its pod CIDR), not
+        # its LAN IP — pods themselves start at .2, so /31s stay tight
+        - ipBlock:
+            cidr: 10.42.0.0/31
+        - ipBlock:
+            cidr: 10.42.1.0/31
+        - ipBlock:
+            cidr: 10.42.3.0/31
+        - ipBlock:
+            cidr: 10.42.4.0/31


### PR DESCRIPTION
The phase-2 default-deny rollout blocked hostNetwork pods (HA) from reaching cluster services on *other* nodes: cross-node traffic sources from the node's flannel/cni host IPs, which the LAN-only allow rule doesn't match. Same-node access worked via the local-node exception, masking this during validation. Symptom: HA's wyoming/piper TTS unavailable after the pod landed cross-node from its backends.

Adds tight /31 ipBlocks for the host-side addresses only (pod IPs start at .2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGT13p3oBuevMaQ4rajfFo