### PR TITLE
hass: ndots:1 for search-path-immune external DNS

### DIFF
--- a/cluster/apps/home/hass/app/helm-release.yaml
+++ b/cluster/apps/home/hass/app/helm-release.yaml
@@ -33,6 +33,15 @@ spec:
           # needed for homekit integration? more research requried.
           hostNetwork: true
           dnsPolicy: ClusterFirstWithHostNet
+          # ndots:1 = external names resolve absolute-first instead of
+          # walking the search-domain list, so one flaky upstream answer
+          # for a search-path variant can't fail the whole lookup
+          # (glibc aborts on SERVFAIL). Cluster shortnames still resolve
+          # via the search path.
+          dnsConfig:
+            options:
+              - name: ndots
+                value: "1"
         containers:
           home-assistant:
             image:


### PR DESCRIPTION
GLaDOS's "error talking to api" this morning: HA resolves its LLM endpoint by public hostname; with ndots:5 that lookup walks the search domains first, and a SERVFAIL on one variant from the upstream resolver aborts the whole resolution (glibc EAI_AGAIN). ndots:1 makes external names resolve absolute-first. Cluster-internal shortnames are unaffected (still searched). Render-validated against app-template 5.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGT13p3oBuevMaQ4rajfFo