### PR TITLE
fix: explicit kustomization for cluster/base

### DIFF
--- a/cluster/base/kustomization.yaml
+++ b/cluster/base/kustomization.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Explicit list: keeps ./components (kustomize Components consumed by app
+# overlays) out of the flux-system build, which cannot accumulate them as
+# resources. New files under cluster/base must be added here.
+resources:
+  - ./apps.yaml
+  - ./cluster-secrets.yaml
+  - ./cluster-settings.yaml
+  - ./flux-system


### PR DESCRIPTION
#1608 added `cluster/base/components/` (kustomize Components). The flux-system Kustomization reconciles `./cluster/base` with no explicit `kustomization.yaml`, so Flux's auto-generated one swept the components dir in as plain resources — kustomize rejects `kind: Component` there, and the flux-system build has been failing since the merge.

This pins an explicit resource list matching what the auto-generated build produced before #1608, so `./components` is only consumed by the overlays that reference it under `components:`. Verified locally: `kubectl kustomize cluster/base` renders 53 resources, no Components leaked. Rendered output is unchanged, so `prune: true` is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHexspp6a4iBxts4Eayun3