### PR TITLE
immich: VectorChord migration (phase A) — SATURDAY

### DIFF
--- a/cluster/apps/immich/immich/database/cluster.yaml
+++ b/cluster/apps/immich/immich/database/cluster.yaml
@@ -8,7 +8,10 @@ metadata:
 spec:
   instances: 1
   enablePDB: false
-  imageName: ghcr.io/tensorchord/cloudnative-pgvecto.rs:16.4-v0.3.0
+  # Migration-window image (vchord + pgvecto.rs 0.3.0) for the immich
+  # pgvecto.rs -> VectorChord reindex; move to plain cloudnative-vectorchord
+  # and drop vectors.so once the vectors schema is gone.
+  imageName: ghcr.io/a-mcf/cnpg-vectorchord-migration:16.14-vchord1.1.1-pgvectors0.3.0@sha256:4898bc79734633a7e5dd71b56a3e85b1f6274f3598d311d237d3673c9edcfbb6
   enableSuperuserAccess: true
   startDelay: 30
   stopDelay: 100
@@ -19,6 +22,7 @@ spec:
       max_connections: "600"
       shared_buffers: 512MB
     shared_preload_libraries:
+      - "vchord.so"
       - "vectors.so"
   storage:
     size: 25Gi


### PR DESCRIPTION
## What

Swaps immich's CNPG cluster to a migration-window image bundling **VectorChord 1.1.1 + pgvector 0.8.2 + pgvecto.rs 0.3.0** ([a-mcf/cnpg-vectorchord-migration](https://github.com/a-mcf/cnpg-vectorchord-migration), digest-pinned, smoke-tested: all three .so present, uid 26, PG 16.14) and preloads `vchord.so` alongside `vectors.so`. Postgres rides 16.4→16.14 (**minor** — same on-disk format, CNPG in-place restart; the no-major-upgrade rule doesn't apply).

Immich v2.7.5 auto-reindexes to VectorChord on next server start. Required before #1578/v3, which drops pgvecto.rs.

## Runbook (Saturday)

1. **Pre:** on-demand `Backup` CR for immich-cnpg; wait for `phase: completed`
2. Merge this PR; cnpg restarts the single instance (brief immich DB outage)
3. If immich can't create extensions itself: `CREATE EXTENSION IF NOT EXISTS vchord CASCADE;` as postgres (harmless if already done)
4. Restart immich-server; watch logs for `Reindexed face_index` + `Reindexed clip_index`
5. Verify UI: smart search + people/faces
6. **Phase B (separate PR):** drop `vectors.so` from preload, `DROP SCHEMA vectors CASCADE;`, move image to plain `cloudnative-vectorchord:16.14-1.1.1`, then chart-bump to v3 (supersedes #1578 — server tag alone is insufficient, ML image comes from chart appVersion)

## Rollback

Revert this PR (image swap back is safe pre-reindex); worst case restore from the step-1 backup.

**DRAFT — do not merge before the Saturday window.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHexspp6a4iBxts4Eayun3