### PR TITLE
immich: retire migration db image, vchord only

### DIFF
--- a/cluster/apps/immich/immich/database/cluster.yaml
+++ b/cluster/apps/immich/immich/database/cluster.yaml
@@ -8,10 +8,7 @@ metadata:
 spec:
   instances: 1
   enablePDB: false
-  # Migration-window image (vchord + pgvecto.rs 0.3.0) for the immich
-  # pgvecto.rs -> VectorChord reindex; move to plain cloudnative-vectorchord
-  # and drop vectors.so once the vectors schema is gone.
-  imageName: ghcr.io/a-mcf/cnpg-vectorchord-migration:16.14-vchord1.1.1-pgvectors0.3.0@sha256:4898bc79734633a7e5dd71b56a3e85b1f6274f3598d311d237d3673c9edcfbb6
+  imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.14-1.1.1@sha256:4a26ca6aad2482289f4a3d3317ccbf1439ce3de140994598375a1f4c4e2e9f8d
   enableSuperuserAccess: true
   startDelay: 30
   stopDelay: 100
@@ -23,7 +20,6 @@ spec:
       shared_buffers: 512MB
     shared_preload_libraries:
       - "vchord.so"
-      - "vectors.so"
   storage:
     size: 25Gi
     storageClass: proxmox-csi-ext4-ssd


### PR DESCRIPTION
Phase B of the VectorChord migration (follow-up to #1619). The `vectors` extension and schema are dropped and nothing depends on them (verified via pg_depend); this moves the cluster to the plain `cloudnative-vectorchord` operand image and removes `vectors.so` from preload. One rolling restart of the single instance.

Remaining for v3: immich chart bump (supersedes #1578).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHexspp6a4iBxts4Eayun3