### PR TITLE
immich: v3.0.1 via chart 0.13.1 (OCI repo)

### DIFF
--- a/cluster/apps/immich/immich/app/helm-release.yaml
+++ b/cluster/apps/immich/immich/app/helm-release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: immich
-      version: 0.12.0
+      version: 0.13.1
       sourceRef:
         kind: HelmRepository
         name: immich-charts
@@ -51,7 +51,7 @@ spec:
   
             image:
               repository: ghcr.io/immich-app/immich-server
-              tag: v2.7.5
+              tag: v3.0.1
 
     server:
       controllers:

--- a/cluster/base/flux-system/charts/helm/immich-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/immich-charts.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://immich-app.github.io/immich-charts
+  type: oci
+  url: oci://ghcr.io/immich-app/immich-charts


### PR DESCRIPTION
Final phase of the v3 upgrade (after #1619/#1620 VectorChord migration):

- HelmRepository → `type: oci` (chart 0.13.x is not published to the HTTP index)
- chart 0.12.0 → 0.13.1 (appVersion v3.0.0; 0.13.0's breaking values schema validated against our values via `helm template` — renders clean, guards pass)
- server tag override v2.7.5 → v3.0.1; the top-level override propagates to machine-learning too, so server + ML move together

Supersedes #1578 (server-tag-only bump; ML would have stayed behind and pgvecto.rs was still in place when it was opened).

Post-merge: re-run Metadata Extraction job (enables realtime transcoding for pre-v3 videos); mobile apps must be current (v3 API changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHexspp6a4iBxts4Eayun3