### PR TITLE
immich: conform values to chart 0.13 schema

### DIFF
--- a/cluster/apps/immich/immich/app/helm-release.yaml
+++ b/cluster/apps/immich/immich/app/helm-release.yaml
@@ -56,15 +56,19 @@ spec:
     server:
       controllers:
         main:
-          resources:
-            requests:
-              cpu: 1500m
-              memory: 2048M
+          containers:
+            main:
+              resources:
+                requests:
+                  cpu: 1500m
+                  memory: 2048M
       persistence:
         external:
           enabled: true
           existingClaim: nfs-immich-photprism-originals-pvc
-          readOnly: true
+          globalMounts:
+            - path: /external
+              readOnly: true
       ingress:
         main:
           enabled: true
@@ -82,20 +86,16 @@ spec:
             - hosts:
                 - immich.${SECRET_DOMAIN}
 
-    microservices:
-      persistence:
-        external:
-          enabled: true
-          existingClaim: nfs-immich-photprism-originals-pvc
-          readOnly: true
-
     machine-learning:
       controllers:
         main:
-          resources:
-            requests:
-              cpu: 500m
-              memory: 4096M
+          containers:
+            main:
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 4096M
       persistence:
         cache:
+          type: persistentVolumeClaim
           existingClaim: nfs-immich-ml-cache-pvc


### PR DESCRIPTION
#1621 follow-up: the 0.13 upgrade failed helm's values-schema validation (harmless — validation runs before apply, v2.7.5 kept running). The rejected shapes turn out to have been **silently ignored by chart 0.12 all along** — live deployments confirm none of them ever applied:

- `resources` sat at controller level → both deployments have empty resources
- `readOnly: true` at persistence-item level → external library is mounted read-write
- ML `cache.existingClaim` without `type: persistentVolumeClaim` → cache is an emptyDir (models re-download every restart)
- `microservices:` block → component removed from the chart ages ago

Restructured per bjw-s common 5.0.1: resources under `containers.main`, readOnly via `globalMounts`, explicit pvc type on the cache, dead block dropped. Validated with helm 3.19 strict schema — renders v3.0.1 server+ML, all three PVCs, resources present.

Net effect beyond unblocking v3: our intended config becomes real for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHexspp6a4iBxts4Eayun3