### PR TITLE
immich: 15m helm timeout for in-startup db migrations

### DIFF
--- a/cluster/apps/immich/immich/app/helm-release.yaml
+++ b/cluster/apps/immich/immich/app/helm-release.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: immich
 spec:
   interval: 5m
+  # DB migrations run inside server startup; give upgrades room so helm's
+  # wait doesn't expire mid-migration and trigger a rollback the migrated
+  # schema can't satisfy.
+  timeout: 15m
   chart:
     spec:
       chart: immich


### PR DESCRIPTION
The #1622 upgrade applied cleanly but helm's default 5m wait expired while the v3 server pod was still coming up post-migration; the automatic rollback reinstated v2.7.5, which can't start against the already-migrated schema (kysely: "previously executed migration missing"). Forward is the only direction: migrations are already applied, so a retried v3 upgrade starts fast. This bumps the HelmRelease timeout so future migration-bearing upgrades don't hit the same trap, and the spec change resets the remediation counter to trigger that retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHexspp6a4iBxts4Eayun3