### PR TITLE
immich: v3 ML preload env split (textual/visual)

### DIFF
--- a/cluster/apps/immich/immich/app/helm-release.yaml
+++ b/cluster/apps/immich/immich/app/helm-release.yaml
@@ -37,7 +37,8 @@ spec:
         containers:
           main:
             env:
-              MACHINE_LEARNING_PRELOAD__CLIP: "ViT-H-14-378-quickgelu__dfn5b"
+              MACHINE_LEARNING_PRELOAD__CLIP__TEXTUAL: "ViT-H-14-378-quickgelu__dfn5b"
+              MACHINE_LEARNING_PRELOAD__CLIP__VISUAL: "ViT-H-14-378-quickgelu__dfn5b"
               # UPLOAD_LOCATION: /data
               DB_HOSTNAME: immich-cnpg-rw
               DB_USERNAME:


### PR DESCRIPTION
The v3 upgrade's remaining blocker: the ML container crash-loops because v3 parses `MACHINE_LEARNING_PRELOAD__CLIP` as a nested settings model — a bare model name raises `SettingsError: error parsing value for field \"preload\"` (reproduced in an isolated pod with the same image/env/mount). v3 wants the `__CLIP__TEXTUAL` / `__CLIP__VISUAL` pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHexspp6a4iBxts4Eayun3