### PR TITLE
feat(gluetun): enable http proxy request logging

### DIFF
--- a/cluster/apps/gluetun/gluetun/app/helm-release.yaml
+++ b/cluster/apps/gluetun/gluetun/app/helm-release.yaml
@@ -27,6 +27,9 @@ spec:
               VPN_SERVICE_PROVIDER: surfshark
               VPN_TYPE: wireguard
               HTTPPROXY: "on"
+              # one log line per proxied request (hostname only, not content);
+              # the observable for which apps are riding the tunnel
+              HTTPPROXY_LOG: "on"
               # the proxy port must be allowed through gluetun's own
               # killswitch firewall
               FIREWALL_INPUT_PORTS: "8888"


### PR DESCRIPTION
Codifies the `HTTPPROXY_LOG=on` already applied live via kubectl set env (drift otherwise silently reverts on next helm upgrade). One log line per proxied request, hostname only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114y5tZckbaz5RMbNqrwVQJ