### PR TITLE
feat: add radicale CardDAV/CalDAV server

### DIFF
--- a/cluster/apps/kustomization.yaml
+++ b/cluster/apps/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
   - paperless
   - photoprism
   - proxmox-csi
+  - radicale
   - retrosavemanager
   - retrosync
   - searxng

--- a/cluster/apps/radicale/kustomization.yaml
+++ b/cluster/apps/radicale/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./radicale/ks.yaml
+  - ./netpol

--- a/cluster/apps/radicale/namespace.yaml
+++ b/cluster/apps/radicale/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: radicale

--- a/cluster/apps/radicale/netpol/kustomization.yaml
+++ b/cluster/apps/radicale/netpol/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: radicale
+components:
+  - ../../../base/components/netpol/baseline
+  - ../../../base/components/netpol/ingress-controller

--- a/cluster/apps/radicale/radicale/app/config-pvc.yaml
+++ b/cluster/apps/radicale/radicale/app/config-pvc.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-radicale-data-pv
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  mountOptions:
+    - nfsvers=4
+    - port=2049
+  nfs:
+    path: /tank/appdata/radicale-data
+    server: "${NFS_SERVER}"
+  persistentVolumeReclaimPolicy: Retain
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-radicale-data-pvc
+  namespace: radicale
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: nfs-radicale-data-pv

--- a/cluster/apps/radicale/radicale/app/helm-release.yaml
+++ b/cluster/apps/radicale/radicale/app/helm-release.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: radicale
+  namespace: radicale
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  values:
+    controllers:
+      radicale:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: tomsquest/docker-radicale
+              tag: 3.7.5.0@sha256:e4e694f859c5580c8e925d15905cae36b378150b43ab9b71c52f9cfeed4a3906
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 5232
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        # k8sappdata on the NFS export
+        runAsNonRoot: true
+        runAsUser: 2316
+        runAsGroup: 2316
+        fsGroup: 2316
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: 5232
+    ingress:
+      main:
+        enabled: true
+        className: traefik
+        annotations:
+          hajimari.io/enable: "true"
+          hajimari.io/icon: calendar-account
+          hajimari.io/info: Family Calendar & Contacts
+          hajimari.io/group: tools
+        hosts:
+          - host: &host "dav.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - hosts:
+              - *host
+    persistence:
+      data:
+        existingClaim: nfs-radicale-data-pvc
+        globalMounts:
+          - path: /data
+      config:
+        type: configMap
+        name: radicale-configmap
+        globalMounts:
+          - path: /config/config
+            subPath: config
+            readOnly: true
+      users:
+        type: secret
+        name: radicale-secret
+        globalMounts:
+          - path: /etc/radicale/users
+            subPath: users
+            readOnly: true

--- a/cluster/apps/radicale/radicale/app/kustomization.yaml
+++ b/cluster/apps/radicale/radicale/app/kustomization.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: radicale
+resources:
+  - ./secret.sops.yaml
+  - ./config-pvc.yaml
+  - ./helm-release.yaml
+configMapGenerator:
+  - name: radicale-configmap
+    files:
+      - config=./resources/config
+    options:
+      disableNameSuffixHash: true

--- a/cluster/apps/radicale/radicale/app/resources/config
+++ b/cluster/apps/radicale/radicale/app/resources/config
@@ -1,0 +1,21 @@
+[server]
+hosts = 0.0.0.0:5232
+
+[auth]
+type = htpasswd
+htpasswd_filename = /etc/radicale/users
+htpasswd_encryption = autodetect
+# slow down brute force over the (VPN-only) network anyway
+delay = 2
+
+[rights]
+# family-trust model: any authenticated user can read/write all
+# collections, so shared calendars just work; tighten with a rights
+# file later if separation is ever wanted
+type = authenticated
+
+[storage]
+filesystem_folder = /data/collections
+
+[logging]
+level = info

--- a/cluster/apps/radicale/radicale/app/secret.sops.yaml
+++ b/cluster/apps/radicale/radicale/app/secret.sops.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: radicale-secret
+    namespace: radicale
+stringData:
+    users: ENC[AES256_GCM,data:N0f3PdCsZtQTT1p+cqRIpUMkw7WE6nEM6ZgmYy7VMeA5x9JWS3jB4MK/M98s8KbS+5c8H02j1/YWtXG2rwPW7BD6dIw3onuQG7kiKrb3MkS3Pk7bxHQjAjlDBPd0f/sNK6tYYON/PrXBzKcGbc5Q/oDSr8WF+EwlSjqb6+ej7sgUYRAlhGtDDnTYOh57U5El/N2m1VEIxikOKzG7vUoedrJi+RSkdLvJ5gdm3jcZetHrcMx9hfynQM4ihSlGR/fUxjYPw6QTmu4=,iv:7sbJ35d6xuS+u7UJBfGq+znqHwl6XFjRijkWtWjXo/c=,tag:75N1FJ3LTshgaVzaZoIx7A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-10T19:46:22Z"
+    mac: ENC[AES256_GCM,data:9qIneawFaBFolC6DUILZusXDk26Fkhx8aBPspchzweLnGDLyFaHPueE0C8nMFkN7cphFvMtcycfRNNuy5IjvjisNRxn7rh4PJJk0+sJPCJbVIYIlGDqcdaRjWkh6GJ0BLfipkkPkCcuQSqW7jAbI9Pk+wQbn9AIm9MdVYVaY46c=,iv:mBZWFWRBCpJeeg1+VR0jUZcVnloGWQGoKBreAlHOP+g=,tag:S3EYYgEAOvGp+CYT61XS2A==,type:str]
+    pgp:
+        - created_at: "2026-07-10T19:46:21Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0dSZMvnEisuAQ/8C5WVSyBuQ4pAhGKAyjNzWv58On2nR+kDy7amK0IMvMoV
+            0ZoboUYeFUmJFyuHxZyj+FeQufvw01lQ64mO32qgO+9iaGvk5L0cjWmJV1QbMxTR
+            HLAT/yaqYy89r202fz3J75dS7S+GqcAWzfj7709nOANs8Va89t9W1IXlHn5v1j9M
+            SYDMk9KhGspiTlBU0s3BUdOUrxqNGEkYcL109MPlOYb6viGCJ3kocqKIOLNBiw/S
+            OovH3E43LCHFKQgm9V26ez8YaBJNybH9LBG2VrEQ0TJilRIsjwJeRKZglVYK+mjX
+            PPwFsFkb9Od1USB5pQpCN4/APOY7Hnc1rc6Gs63I+e+6IjMWaSZz5TCNg2pyRn2e
+            MsgtM53jCxiVJpQuGymXOJTDlchN1qddMKP4EONxiJgAoRYgqPOeyT/tEwG3HuzZ
+            74MI+N0JGifS5azW5s0YFfWQj/stZbCNPGbii5lmLJfT4tEMSkY/oQt4mdaLw8mV
+            +0yNQQDUyUbzYDHrEncrTkczNdex0ipf/b6oMmv2RkuVYI1JSmFln7jY4WIVOeYN
+            28FGvPhI8kxrwAzmLCETDaNYTtARFnBVuJVkiKvNJ9a8VQrE8ILJQlaFRTTZ6Rlq
+            da685shN78pJkN5FgoK8X2GTaOa7jmaKHFVJHlw7qwZJgCy072GaVKftJnG/D5XS
+            XAE1ZI+gMJiV9hzkmu+yVKdNt9Uq4GqBz8pDTzLTpDugT1H612VnB2sM5uhHg1hN
+            gCBChH6ai6ZygErHluhuLRpq2OnGxlN3nEWydnON6PPOrpvpe2XuN0VrQ4xP
+            =4z7g
+            -----END PGP MESSAGE-----
+          fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
+        - created_at: "2026-07-10T19:46:21Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAxbwxdi5IniFARAAlVXfugLiPb8YPwuQ5ZbMD4TGhgK4ioSX6v0i65t6YWqo
+            9gchiF0ZkzW3kUVQcHtKRO2Me4HhbK3IBrWI5jK3Br5RmEoSfRe244KRtNG3FL9B
+            M22paxanq4OQYmMdNF0JODikIQqX/7SOehCH5QKY8SwGejZj1Q2c+LH3zehsczSF
+            v8CHPbMEgw0Gc1axGdmPAvTWstuiJhFoymVFd8pvqVgcSVUbR4LsGYUTFhiugOUG
+            eQVUsKoOuQhmHrcDUI3jMsAidYRWusX3pm7WF2MziXY9uV0BJpHE4U98W0DCnMIc
+            GY/1eY39o8gTk5MXBqqPNteLPSs/SfILhmh1oI3N7hCPAIYTUQJSI0bt1PPTYDo4
+            SpcFYKLIp/zd04HeGF30epFBsRWkRorwtBbG1H0mwoupy5WPbbnj89Fes/Czm5Kh
+            VZYUdGbSxbCq7Kovw/wibiobagKsj2PdhYPsdkmclrHUZZUnvUoECB3rdxkMQS8j
+            da2Zt7iCs45qeewZo33J7B2cPSEtmAI7K0tijWAgnEqxrlDb3EdsO0McZb4SH1sw
+            Rw57a/VGB6Oqvd4+EbaWKpUSiLhukC6uFmcbKoi+cQCCUf3xVopqjPbdUmqLIzg7
+            fyuYaH7IszlYtGjF6vvWDITd5vQADrgz9tp9vk5jx5BeN2QdQPmLQj5hKI487YjS
+            XAEjTRtjyU8G6AzWk8cVDK1/dNRuE+Gc1OhkF7JZZss2BnFXyXHnIAM+QPkoSL4a
+            k5z04gZnZ+v11rbPhkWIlowRp9HwtdA3dwMH2azNAY/xtD/r+N33L6SX5ZUh
+            =OLDG
+            -----END PGP MESSAGE-----
+          fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/cluster/apps/radicale/radicale/ks.yaml
+++ b/cluster/apps/radicale/radicale/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-radicale
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/radicale/radicale/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Radicale 3.7.5.0 (digest-pinned, app-template) serving CardDAV/CalDAV for family calendar + contacts — replaces reliance on provider-locked calendar/contacts apps with standard protocols every native client speaks.

- NFS-backed collections storage (export landed via home_infra#112)
- htpasswd auth (SOPS-encrypted), bcrypt, auth delay
- family-trust rights (`type: authenticated`) so shared collections work
- internal traefik ingress only; baseline default-deny + ingress-controller netpol
- non-root (k8sappdata), read-only rootfs, no SA token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114y5tZckbaz5RMbNqrwVQJ