### PR TITLE
feat(radicale): add shared family account

### DIFF
--- a/cluster/apps/radicale/radicale/app/secret.sops.yaml
+++ b/cluster/apps/radicale/radicale/app/secret.sops.yaml
@@ -4,54 +4,54 @@ metadata:
     name: radicale-secret
     namespace: radicale
 stringData:
-    users: ENC[AES256_GCM,data:N0f3PdCsZtQTT1p+cqRIpUMkw7WE6nEM6ZgmYy7VMeA5x9JWS3jB4MK/M98s8KbS+5c8H02j1/YWtXG2rwPW7BD6dIw3onuQG7kiKrb3MkS3Pk7bxHQjAjlDBPd0f/sNK6tYYON/PrXBzKcGbc5Q/oDSr8WF+EwlSjqb6+ej7sgUYRAlhGtDDnTYOh57U5El/N2m1VEIxikOKzG7vUoedrJi+RSkdLvJ5gdm3jcZetHrcMx9hfynQM4ihSlGR/fUxjYPw6QTmu4=,iv:7sbJ35d6xuS+u7UJBfGq+znqHwl6XFjRijkWtWjXo/c=,tag:75N1FJ3LTshgaVzaZoIx7A==,type:str]
+    users: ENC[AES256_GCM,data:cN8Us/AQkMNceU6hAjBfVoLy8UBb+cMHadj5etN6JUeV/T/9FThGWP5Q+VIVJNAwrX2gyIT05issv1suCpIZI0AorXOPXdL0DpS/GuOd5ZN1ifF6QwYL08rUn0eODtTYLHEYLioAREKNdWdIDH75FGkQ4rQpdg1kAz7L+0UfUxHxF8pKUwzQ68gUpskRVOHYQ8EkSLEdxyJVghP0CL5lAchqioycd6ZqOo70TA30iU03fEOTg4EwAj3LILKTa09I+fhjSyl5mA2R0ZQiCWcvJLV1DD3yhZ3/AoGgnXTlO1ALA0+QysyrzIT83sz12TGS95+bheNS0T6LNBvlKM5CXzrZDZuhbkMlcYd9yg==,iv:C2khtabKToEdGCONIXPwOWN5ohlvLh/zGLl1ClW1JxI=,tag:8q9/bqiZLMeiMmY8eav2fg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2026-07-10T19:46:22Z"
-    mac: ENC[AES256_GCM,data:9qIneawFaBFolC6DUILZusXDk26Fkhx8aBPspchzweLnGDLyFaHPueE0C8nMFkN7cphFvMtcycfRNNuy5IjvjisNRxn7rh4PJJk0+sJPCJbVIYIlGDqcdaRjWkh6GJ0BLfipkkPkCcuQSqW7jAbI9Pk+wQbn9AIm9MdVYVaY46c=,iv:mBZWFWRBCpJeeg1+VR0jUZcVnloGWQGoKBreAlHOP+g=,tag:S3EYYgEAOvGp+CYT61XS2A==,type:str]
+    lastmodified: "2026-07-10T19:58:43Z"
+    mac: ENC[AES256_GCM,data:Ru1jysGg2zGeXmba7HbjYo2otfbDBq0fbLr5+GuOrebALUdPdDuPcGbLYMwFjHHO4fCY3pFNKVh95rUW8P0vjzBn3NyGknrmaD78hChfv7V7h8lMZSswsG9ShuTU7k276AijF8pWUdoNHOJQUEKlVI20jRcOz4PdpQFcWibaQlM=,iv:sIFYd1RoEbRTrQreJ4Hi/iIkz5hsWT7YXiv4pjcfkog=,tag:4IBal4bQnCdSoEWOBU2wEA==,type:str]
     pgp:
-        - created_at: "2026-07-10T19:46:21Z"
+        - created_at: "2026-07-10T19:58:42Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0dSZMvnEisuAQ/8C5WVSyBuQ4pAhGKAyjNzWv58On2nR+kDy7amK0IMvMoV
-            0ZoboUYeFUmJFyuHxZyj+FeQufvw01lQ64mO32qgO+9iaGvk5L0cjWmJV1QbMxTR
-            HLAT/yaqYy89r202fz3J75dS7S+GqcAWzfj7709nOANs8Va89t9W1IXlHn5v1j9M
-            SYDMk9KhGspiTlBU0s3BUdOUrxqNGEkYcL109MPlOYb6viGCJ3kocqKIOLNBiw/S
-            OovH3E43LCHFKQgm9V26ez8YaBJNybH9LBG2VrEQ0TJilRIsjwJeRKZglVYK+mjX
-            PPwFsFkb9Od1USB5pQpCN4/APOY7Hnc1rc6Gs63I+e+6IjMWaSZz5TCNg2pyRn2e
-            MsgtM53jCxiVJpQuGymXOJTDlchN1qddMKP4EONxiJgAoRYgqPOeyT/tEwG3HuzZ
-            74MI+N0JGifS5azW5s0YFfWQj/stZbCNPGbii5lmLJfT4tEMSkY/oQt4mdaLw8mV
-            +0yNQQDUyUbzYDHrEncrTkczNdex0ipf/b6oMmv2RkuVYI1JSmFln7jY4WIVOeYN
-            28FGvPhI8kxrwAzmLCETDaNYTtARFnBVuJVkiKvNJ9a8VQrE8ILJQlaFRTTZ6Rlq
-            da685shN78pJkN5FgoK8X2GTaOa7jmaKHFVJHlw7qwZJgCy072GaVKftJnG/D5XS
-            XAE1ZI+gMJiV9hzkmu+yVKdNt9Uq4GqBz8pDTzLTpDugT1H612VnB2sM5uhHg1hN
-            gCBChH6ai6ZygErHluhuLRpq2OnGxlN3nEWydnON6PPOrpvpe2XuN0VrQ4xP
-            =4z7g
+            hQIMA0dSZMvnEisuAQ//ZOgBo9IapWh8jMDR+Iwnm+P3hLeWFxNq6GkAlVyz6dL2
+            Ivm5nFtlfEejL/RSMd22jP5n+oLJaWwlkM1fZXTzvNE7uzIyc9JutPvKokZj+gTX
+            mLRMi0GKNZTC/2Zt4lRW8K+VrZrT5F1ZZ8/qArxnwlbd8EUQIUEPqvgdYYADI4VZ
+            CS97FWzar0YLZwFt43OOuMBVbYI1jYKbIKRiBiSWRAIieT71EK6HZfPZEMWTGdh5
+            Dv9WzBkNaX77cqe4ONV81V2QoiyGY8aOd316f5/Gd8ex6gW16UWldaaQInCne6aW
+            VgT0cONJrnM+sOBYbl/67ag+XfLd+SRiepzaulxyH5eRdAMLqYRnypVOO8gPP+78
+            7xDO9lTMmrqpiJXITS+FwHc53h8ckYuJey82bPG+4p2qU+GCnWKItQzQX958K2br
+            wV/C5T7CL2uXmpgJrrhuM3Gwbi9NwvOXgBrUb+zwnwpAy9GPuM6j2AoHvdL3r6WH
+            b0OTtW+5/3ODq8+wZD7QJhjcd4ycMwOhBNiivOkhDPHqr69BjIIzS4C79awQJSrF
+            l+aHjNKlwmRUSwsXUQ0IkRJlYNt22I0nCf+vpKRsXXxPMIarebPy79HL8FrQNKYR
+            PPsJCKrPgurHFd4Zha+bBpmewz4+Pz6dePj6/BhjoxlnmwaPGPlH080Y0ZXWX0fS
+            XgHByMO4RoWMIbsA6XTPaqSlvmb1ZyBydLVzycfdsZljZxvyFqkkxQADHg7DCpw9
+            kRmfNc8XYmv3Rq64eYrlzqxSnNAGwIsx+8mYexrqMauxO/39bmnVpz61BpLVL3w=
+            =A9GN
             -----END PGP MESSAGE-----
           fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
-        - created_at: "2026-07-10T19:46:21Z"
+        - created_at: "2026-07-10T19:58:42Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMAxbwxdi5IniFARAAlVXfugLiPb8YPwuQ5ZbMD4TGhgK4ioSX6v0i65t6YWqo
-            9gchiF0ZkzW3kUVQcHtKRO2Me4HhbK3IBrWI5jK3Br5RmEoSfRe244KRtNG3FL9B
-            M22paxanq4OQYmMdNF0JODikIQqX/7SOehCH5QKY8SwGejZj1Q2c+LH3zehsczSF
-            v8CHPbMEgw0Gc1axGdmPAvTWstuiJhFoymVFd8pvqVgcSVUbR4LsGYUTFhiugOUG
-            eQVUsKoOuQhmHrcDUI3jMsAidYRWusX3pm7WF2MziXY9uV0BJpHE4U98W0DCnMIc
-            GY/1eY39o8gTk5MXBqqPNteLPSs/SfILhmh1oI3N7hCPAIYTUQJSI0bt1PPTYDo4
-            SpcFYKLIp/zd04HeGF30epFBsRWkRorwtBbG1H0mwoupy5WPbbnj89Fes/Czm5Kh
-            VZYUdGbSxbCq7Kovw/wibiobagKsj2PdhYPsdkmclrHUZZUnvUoECB3rdxkMQS8j
-            da2Zt7iCs45qeewZo33J7B2cPSEtmAI7K0tijWAgnEqxrlDb3EdsO0McZb4SH1sw
-            Rw57a/VGB6Oqvd4+EbaWKpUSiLhukC6uFmcbKoi+cQCCUf3xVopqjPbdUmqLIzg7
-            fyuYaH7IszlYtGjF6vvWDITd5vQADrgz9tp9vk5jx5BeN2QdQPmLQj5hKI487YjS
-            XAEjTRtjyU8G6AzWk8cVDK1/dNRuE+Gc1OhkF7JZZss2BnFXyXHnIAM+QPkoSL4a
-            k5z04gZnZ+v11rbPhkWIlowRp9HwtdA3dwMH2azNAY/xtD/r+N33L6SX5ZUh
-            =OLDG
+            hQIMAxbwxdi5IniFAQ//We8h4TnfXR7nrR+p/JhzCmg4q6ox2n9hpqTe/Ns6ibOX
+            lMr+7vVzQJn4JbxNubjuVrk7n/Y1Bed+3KGcCbVwLWiKavf3oDNBacPD4GgiI3D9
+            h50x3kC/POtZNmgnEzhA0t2evY9ygj2LP+5hkXm8S2oHbf0mLLxT1WQTLpkmSdNm
+            dRTA9b0+UqCbthI8t0Y6uOt8NkZSPGu2ymHgvFZyInEzyWkTiBh8Sy7h+OUx9DVI
+            6223xXatXEw3d/k85ijJHpk2qHLMDkjUMTYv2R5fhgCuYWCzc+Abilv57D5ReaPz
+            mb/KGw1rOu8kvfHfqOOggaXSkNvPqXCfWtoYFQ2sslImNBHm0Op36IkexKyqLT/h
+            kxpllNd/lR9NLI2KmMr5AoEkCwA3jFxKRAf7H0fBrDNqYviQxoQy06Q5FZ0+VbFX
+            HvV9jafPkXN7U+KpMdgarvsjR977Ruwr3fJS+tANIaB5ZVg94ts3d1kp3T2hGY4z
+            k14JpBKDmsaZNVNTCTU5N6MiUMQ1hB9J0Z2YEmSNFx2+V29ShWz5U99GHdLA9QmE
+            Y/L3N5ruKq4SMasFbiIwECbpDUFS5zrSQFJ+mcI8H4biCd1NwnwmANEgsKbgLyel
+            O0oit9AIqtMACIYmxJMqAgcA+7zKVEkWbKc9QbWxVeHnk2zDN6f7iIl94+fcsyfS
+            XgF/WXQARDAY1LPxCJvlr0lO63s9V0S3tMXwk/uYv30/w21pk7F9dXMpkO0p7Eqd
+            XvKp3avRjUC/fslLogLySYAtq4hSUyrJeTYdf2Ng+zbqfE04g/Nn9r1O1WG2JR0=
+            =BX5F
             -----END PGP MESSAGE-----
           fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
     encrypted_regex: ^(data|stringData)$


### PR DESCRIPTION
Fourth DAV account holding the shared family calendar; each device adds it as a second CalDAV account (iOS only auto-discovers a principal's own collections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114y5tZckbaz5RMbNqrwVQJ