### PR TITLE
feat(radicale): per-user rights model, fifth user, hostname rename

### DIFF
--- a/cluster/apps/radicale/radicale/app/helm-release.yaml
+++ b/cluster/apps/radicale/radicale/app/helm-release.yaml
@@ -71,7 +71,7 @@ spec:
           hajimari.io/info: Family Calendar & Contacts
           hajimari.io/group: tools
         hosts:
-          - host: &host "dav.${SECRET_DOMAIN}"
+          - host: &host "radicale.${SECRET_DOMAIN}"
             paths:
               - path: /
                 pathType: Prefix
@@ -89,6 +89,9 @@ spec:
         globalMounts:
           - path: /config/config
             subPath: config
+            readOnly: true
+          - path: /etc/radicale/rights
+            subPath: rights
             readOnly: true
       users:
         type: secret

--- a/cluster/apps/radicale/radicale/app/kustomization.yaml
+++ b/cluster/apps/radicale/radicale/app/kustomization.yaml
@@ -11,5 +11,6 @@ configMapGenerator:
   - name: radicale-configmap
     files:
       - config=./resources/config
+      - rights=./resources/rights
     options:
       disableNameSuffixHash: true

--- a/cluster/apps/radicale/radicale/app/resources/config
+++ b/cluster/apps/radicale/radicale/app/resources/config
@@ -9,10 +9,10 @@ htpasswd_encryption = autodetect
 delay = 2
 
 [rights]
-# family-trust model: any authenticated user can read/write all
-# collections, so shared calendars just work; tighten with a rights
-# file later if separation is ever wanted
-type = authenticated
+# personal spaces private to their owner; the `family` account's tree
+# shared read/write by all (see the rights file for the rules)
+type = from_file
+file = /etc/radicale/rights
 
 [storage]
 filesystem_folder = /data/collections

--- a/cluster/apps/radicale/radicale/app/resources/rights
+++ b/cluster/apps/radicale/radicale/app/resources/rights
@@ -1,0 +1,29 @@
+# Radicale rights — FIRST MATCHING RULE WINS, order is load-bearing.
+# Model: own tree = full control; family tree = shared read/write;
+# other users' calendars = read-only; other users' contacts = invisible.
+# Uppercase R/W = the collection itself, lowercase r/w = items within.
+
+# principal discovery at the root
+[root]
+user: .+
+collection:
+permissions: R
+
+# everyone owns their own tree (must precede the read-only rule)
+[own-space]
+user: .+
+collection: {user}(/.*)?
+permissions: RrWw
+
+# the shared family tree (calendar, contacts, tasks, ...)
+[family-shared]
+user: .+
+collection: family(/.*)?
+permissions: RrWw
+
+# anyone may READ another user's calendar (glance at schedules);
+# contacts deliberately have no cross-user rule -> denied
+[other-calendars-read-only]
+user: .+
+collection: [^/]+/calendar(/.*)?
+permissions: Rr

--- a/cluster/apps/radicale/radicale/app/secret.sops.yaml
+++ b/cluster/apps/radicale/radicale/app/secret.sops.yaml
@@ -4,54 +4,54 @@ metadata:
     name: radicale-secret
     namespace: radicale
 stringData:
-    users: ENC[AES256_GCM,data:cN8Us/AQkMNceU6hAjBfVoLy8UBb+cMHadj5etN6JUeV/T/9FThGWP5Q+VIVJNAwrX2gyIT05issv1suCpIZI0AorXOPXdL0DpS/GuOd5ZN1ifF6QwYL08rUn0eODtTYLHEYLioAREKNdWdIDH75FGkQ4rQpdg1kAz7L+0UfUxHxF8pKUwzQ68gUpskRVOHYQ8EkSLEdxyJVghP0CL5lAchqioycd6ZqOo70TA30iU03fEOTg4EwAj3LILKTa09I+fhjSyl5mA2R0ZQiCWcvJLV1DD3yhZ3/AoGgnXTlO1ALA0+QysyrzIT83sz12TGS95+bheNS0T6LNBvlKM5CXzrZDZuhbkMlcYd9yg==,iv:C2khtabKToEdGCONIXPwOWN5ohlvLh/zGLl1ClW1JxI=,tag:8q9/bqiZLMeiMmY8eav2fg==,type:str]
+    users: ENC[AES256_GCM,data:tosVDwQ2Mm7YdWKN48Bm7DHdVHRl4PbSzeXVIrP5kVK8VJqCRZR3PnQoDv/iuHNXY0QmXauOkIoV5k6W7X4OUlhWFTz3e7JEmld3MqOJaZVcX1K3DjAMvCQcCbcq+/Ptxj8nQ0FtPXFQwDXfZo+S7IPui3EbmaEWlGHqcK5w1O34AGdSMoSP9s+/KZDwwZV9Cyw2wFxLiZjjIQFQkJKAGFomPNnqT8ag5hpSZkBWkMRwwE5oPGDofs7DMH4i9/AgCobkkWHgXeXZcaetqK8WI8nSwUg4aTdWzpKUsq5HQ82094GuIL1BUetAP6jHZ2/mgHrHrw3gUwzNFB6jhLnV/5jl0RoHidoutjLepDaWbtbJT4AvFG7cKeYD/v64uvJqSikBR0fixRXK7S6oNzFjQAKXoBYVFSHZuulY91G7vNTVcKQXyshX98DAEUU0yW3r,iv:iRTINSjD3mrltcmA4hxI1DSN74YMMVpaBs4WVqQsiKE=,tag:AsLhwci81dZywlzwYbiOOQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2026-07-10T19:58:43Z"
-    mac: ENC[AES256_GCM,data:Ru1jysGg2zGeXmba7HbjYo2otfbDBq0fbLr5+GuOrebALUdPdDuPcGbLYMwFjHHO4fCY3pFNKVh95rUW8P0vjzBn3NyGknrmaD78hChfv7V7h8lMZSswsG9ShuTU7k276AijF8pWUdoNHOJQUEKlVI20jRcOz4PdpQFcWibaQlM=,iv:sIFYd1RoEbRTrQreJ4Hi/iIkz5hsWT7YXiv4pjcfkog=,tag:4IBal4bQnCdSoEWOBU2wEA==,type:str]
+    lastmodified: "2026-07-11T15:38:54Z"
+    mac: ENC[AES256_GCM,data:mC64RDXWT+WG6cZbdogdOHzO6wg49/W8KKVdEtafD/e3PfblszOBLF//QZ+wc9lGbzkKCfJdH4YLsowTRXvhBgNoNDSPKJGHpq6Spu7l2TGIakRhusLpQvwNsi1o/7mdCEiFmQ5/YrJKrPEiugTUA0pOlMCw7P5bU8eB/VXlAYU=,iv:JQKP0LV2jDjWCG+zisEJ3u9isHtbdJIx3ge3acGCW10=,tag:xmPkEED6qsdNlD/v++HNCQ==,type:str]
     pgp:
-        - created_at: "2026-07-10T19:58:42Z"
+        - created_at: "2026-07-11T15:38:53Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0dSZMvnEisuAQ//ZOgBo9IapWh8jMDR+Iwnm+P3hLeWFxNq6GkAlVyz6dL2
-            Ivm5nFtlfEejL/RSMd22jP5n+oLJaWwlkM1fZXTzvNE7uzIyc9JutPvKokZj+gTX
-            mLRMi0GKNZTC/2Zt4lRW8K+VrZrT5F1ZZ8/qArxnwlbd8EUQIUEPqvgdYYADI4VZ
-            CS97FWzar0YLZwFt43OOuMBVbYI1jYKbIKRiBiSWRAIieT71EK6HZfPZEMWTGdh5
-            Dv9WzBkNaX77cqe4ONV81V2QoiyGY8aOd316f5/Gd8ex6gW16UWldaaQInCne6aW
-            VgT0cONJrnM+sOBYbl/67ag+XfLd+SRiepzaulxyH5eRdAMLqYRnypVOO8gPP+78
-            7xDO9lTMmrqpiJXITS+FwHc53h8ckYuJey82bPG+4p2qU+GCnWKItQzQX958K2br
-            wV/C5T7CL2uXmpgJrrhuM3Gwbi9NwvOXgBrUb+zwnwpAy9GPuM6j2AoHvdL3r6WH
-            b0OTtW+5/3ODq8+wZD7QJhjcd4ycMwOhBNiivOkhDPHqr69BjIIzS4C79awQJSrF
-            l+aHjNKlwmRUSwsXUQ0IkRJlYNt22I0nCf+vpKRsXXxPMIarebPy79HL8FrQNKYR
-            PPsJCKrPgurHFd4Zha+bBpmewz4+Pz6dePj6/BhjoxlnmwaPGPlH080Y0ZXWX0fS
-            XgHByMO4RoWMIbsA6XTPaqSlvmb1ZyBydLVzycfdsZljZxvyFqkkxQADHg7DCpw9
-            kRmfNc8XYmv3Rq64eYrlzqxSnNAGwIsx+8mYexrqMauxO/39bmnVpz61BpLVL3w=
-            =A9GN
+            hQIMA0dSZMvnEisuARAAr3LJvsOCsTANZTetC4uVZ8ZcjV9o7L6BJYeh0bw/PXmH
+            EIUdwUImn4i9lq5vxJ2NAFGLaYeyYuGvYFMTXzpLCDJFjtml/rf1sMyVaO8o1ud+
+            m1hFFoKqlnIQMK6epqb+JAd3yYq/m49s1pRCD7T8hjU0nCiv1jMDloXnu7D+hXkr
+            EpqZB0hFJ7kkAOZvXu2kYWZAAMOf4Eujvhd/9N+YkA9C2HSvfCfu9QTmIsNNl5tq
+            GefLZupWKUxbcfKikGixYyurj/bnP3nTaAJtunWVww879RpxQDHeQLwOlAiLw1Ik
+            4DLtUtxB5EQ+2xXhswvuzIBKhIS6xIMlPdqI7UXPInqJd7KsEWomifL7nicEQTU4
+            9+ozntDV+PyLxSYsa0IcKLoS2D/9LjdKwOhEmKuqUy9NqoII67cpVTg5ZqbkFU8i
+            B0mSFUISM2oPCra8XmNp5/RoNpEo7trj61U3RH2buQ9QzWsBUnP5j8DyS+wsLhE+
+            WFlTtvTkKrO0p7/9EF0d996DogCuoXl8n41CGDRkt5E+PJiMH3pAzlFLEw+hu7h0
+            RVvAlPtdiU1AgJkIxAG/KE7b2Uf5COJHiPsfwstUjdS5EKvsYty7QGgIVSCcEK6o
+            bTRIhcr6KTVbRXismWl2tW31yvvvkHhcfazn7O3uFnEQsQ4VUHhdcRgXrwlhLkzS
+            XAGN4f5axRchlGZVz5sFSiPyavDsWJwZAjInzambyFGVlOz3n/XwBCvRUlqCK6m7
+            MSvZ4+uvoa4VScb5KWHfeEZVdbkEto/bvzS7DKNunZvRjayrqGlgYRiCAnJ7
+            =/ARC
             -----END PGP MESSAGE-----
           fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
-        - created_at: "2026-07-10T19:58:42Z"
+        - created_at: "2026-07-11T15:38:53Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMAxbwxdi5IniFAQ//We8h4TnfXR7nrR+p/JhzCmg4q6ox2n9hpqTe/Ns6ibOX
-            lMr+7vVzQJn4JbxNubjuVrk7n/Y1Bed+3KGcCbVwLWiKavf3oDNBacPD4GgiI3D9
-            h50x3kC/POtZNmgnEzhA0t2evY9ygj2LP+5hkXm8S2oHbf0mLLxT1WQTLpkmSdNm
-            dRTA9b0+UqCbthI8t0Y6uOt8NkZSPGu2ymHgvFZyInEzyWkTiBh8Sy7h+OUx9DVI
-            6223xXatXEw3d/k85ijJHpk2qHLMDkjUMTYv2R5fhgCuYWCzc+Abilv57D5ReaPz
-            mb/KGw1rOu8kvfHfqOOggaXSkNvPqXCfWtoYFQ2sslImNBHm0Op36IkexKyqLT/h
-            kxpllNd/lR9NLI2KmMr5AoEkCwA3jFxKRAf7H0fBrDNqYviQxoQy06Q5FZ0+VbFX
-            HvV9jafPkXN7U+KpMdgarvsjR977Ruwr3fJS+tANIaB5ZVg94ts3d1kp3T2hGY4z
-            k14JpBKDmsaZNVNTCTU5N6MiUMQ1hB9J0Z2YEmSNFx2+V29ShWz5U99GHdLA9QmE
-            Y/L3N5ruKq4SMasFbiIwECbpDUFS5zrSQFJ+mcI8H4biCd1NwnwmANEgsKbgLyel
-            O0oit9AIqtMACIYmxJMqAgcA+7zKVEkWbKc9QbWxVeHnk2zDN6f7iIl94+fcsyfS
-            XgF/WXQARDAY1LPxCJvlr0lO63s9V0S3tMXwk/uYv30/w21pk7F9dXMpkO0p7Eqd
-            XvKp3avRjUC/fslLogLySYAtq4hSUyrJeTYdf2Ng+zbqfE04g/Nn9r1O1WG2JR0=
-            =BX5F
+            hQIMAxbwxdi5IniFAQ/9FHltauR1juOXKHsHx6hkk5h5vqPeFhqhw5haVDh2D+KW
+            jyXuU+r+lYumDJ/xw/nEuy0R628ZSiHsSYJkcD1Z+BC7ptOcCIZMMqE+8Pi5DhXA
+            aQocYyvOMjvzSY8L7BSkc0NDaRUlfW7r1CLXgS37Fzqdffk9+2747xsHfa45Nk3y
+            Jfa7H3CIFhzIB76c2qRUYvKjSRvQT3paJi9S8SmJsE9k8/sryQGc1kVJITprO8oa
+            UTgSHyjvGY3wKUY51ZMTZxVTiGLqqLuz6R1cMzls/AVAMrUDpNwQebRdIdQq0EOy
+            eQgjOPseoh477sEkxaCWK4OiL5L79fETN11Z6BF0QYvY8PcbFMO6YGYEv3IULFF/
+            m9+K6y+qc5dCnvapAl6Y31CCJxnesjMTsc6YWOh8ybvzGbd7ysuR7kUWul995wgE
+            ijc/b7V6ifElWbGUCKFucwfYiD7NwYLxX2IlYcLwZduBiDjbJtLWSME1pakRt/01
+            reM7BFQ7esRRtNF408rrwgbbxF4Ya1FhxDCvNE6NjNQoz1ccFskbOA9Sohq5AKkS
+            E1gN8HhYI+FpV9eY9vi01w6fDHrPk9JFPt8z/ATh0lm+Ld1pPJKAx4glJnIq08en
+            BciphBfMzI5CT84pP0jV8vz/m6TVCqr+pxs6CROUGFkSeyxMSqj5Cx8u644bkj7S
+            XAHCFwVDyZwYl+kz3bFw2rGtuEw586FRHjogZnycKuB67P5m9w5fQMNQril//Hno
+            3UYKS56KePiEvGhrcuu/phgfDYnjkhrquET0WchK2/B8RCih48VZDQYLe8xu
+            =CJ/X
             -----END PGP MESSAGE-----
           fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
     encrypted_regex: ^(data|stringData)$


### PR DESCRIPTION
Hardening round after family design discussion:

- rights: `authenticated` → `from_file` — own tree full control, `family` tree shared RW for all, **other users' calendars read-only, other users' contacts inaccessible** (first-match-wins rule ordering is load-bearing, see comments)
- fifth account added; all credentials rotated
- ingress hostname → `radicale.` (namespacing for future DAV things)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114y5tZckbaz5RMbNqrwVQJ