### PR TITLE
feat(radicale): activate proton-mirror for first user

### DIFF
--- a/cluster/apps/radicale/proton-mirror/app/helm-release.yaml
+++ b/cluster/apps/radicale/proton-mirror/app/helm-release.yaml
@@ -21,9 +21,9 @@ spec:
         type: cronjob
         cronjob:
           schedule: "*/15 * * * *"
-          # suspended until the mirrors.json secret holds real ICS links +
-          # credentials; flip to false to go live
-          suspend: true
+          # entries waiting on credentials live in mirrors-pending.json
+          # inside the secret; move them into mirrors.json to activate
+          suspend: false
           concurrencyPolicy: Forbid
           successfulJobsHistory: 1
           failedJobsHistory: 2

--- a/cluster/apps/radicale/proton-mirror/app/secret.sops.yaml
+++ b/cluster/apps/radicale/proton-mirror/app/secret.sops.yaml
@@ -4,54 +4,55 @@ metadata:
     name: proton-mirror-secret
     namespace: radicale
 stringData:
-    mirrors.json: ENC[AES256_GCM,data:x9Gn9eFC+p7hU1/pfa4nibufi6kCI0lHNAvvsS5qKPp0NWdgQiBh8Z5h0W67P46r9wKsxVArSfUc9UFEhzciJo83ih4OXWHaow0nU4q1YpW0BH6f5uI4Iu69wKc3B2FedTOBrF6f5xo1Rxmmn82dmUNEa52uqar2IhA6T3HBCodvcpBonKfE0bEuIr09BfIWXeilxD1O9sZz8hvamncZyrYW3Fw6s9yoVrbD+fKn/dVXuBar0hxLLUM/VrGC+TAwtrgwK+W7MvT8/ZiIFkN2tF1aaIBJfkTt5EiER+M2bbd26gF1mhyv1WDKwffKdkx+P+jI5WQs8dOGPmClMc+sj9mWZFDoEPgkzZyhsMsGFR0DwOJUE5ChFefhS3nctFD4QSZaWEdaQHRCBBql2xZ1+wp77S+uyGBpag==,iv:fC8Mb/9mb+aB4W0sndXIv2qOEYEjWxMVzIecJrXDe/U=,tag:nsPd5K6wej1UwdtHHOrzkA==,type:str]
+    mirrors.json: ENC[AES256_GCM,data:4f6xAFWHwfJLI2eIDWdOJJri95lPZwRs7SEdJA9OZ2G0RFtCKQe8UOAHEy5S7hq9wRN1+c+0M7K7JgI8C7+iKLrkVmAdc/3vM1TNCfAaIMRqC8gaSOOvOlDZryDLpXAOPZKzvhTU3WqjqVN1KN48fjNOSTswcOceEpyqFDSgqLEemjDT4gcBrsYEmplx6HLi63upj3w/nJ6Xdx9M/gpXaAXXIA8vffh629F7818lOhCHsBTLJw42srsCTxR2i/Wp5kdk5vZ7fINkRSMh7Se4FQWa7KzC3EDttF7sCydlUvi5nbwSxbKAQRSPJtgGm8Dbt6/rA5qgIJz1TwCg4XloYX0dK18P3qacVh+Kjd5VqhHPdHXbNpaMP1r5EXVbaZCRPlu+qXhepif2WcD5Z6o6sThdBewm5R4H34SMQLqkiBQ5ZlVyZM4EFAnLdm3iN+mGHrGlVcRgBi6UHNOQOdTl6s8v5GP47/kz/AXO2jNTO1YwVXR4Flo=,iv:Qnow0H8IfecAwKoTz/aT7ZUn9G/ZFTwMDHC00r0bNro=,tag:0AYZG1EsDvIIc4zUq5J6DA==,type:str]
+    mirrors-pending.json: ENC[AES256_GCM,data:jNPXwBxyBmaXU78YF7ABKkVR4sgpYVI8NG1bHusjP96dVCfJs0Q7qK2xSs0ktqPkjpUCLiGP0zEH6fixo6XhXJHR5Uv5xwj8WtzOfJX7ApCQ6LE8/3Ku10Z933yMbnCeHB+brj3IZF8JEzycXBuaxx5F31r0IERfnpIxRqQCOd0X99KmeDk98oRPgdkrdzDst3b4vVPL2tswrTHRp/O09G6Ri+M/WoXaddzg,iv:OBrmTfyOamyo4EAmpthOo0vdIiVCk68Psid8Y2SRx+g=,tag:/Qw0Qjs3cKMekp46U/xT+Q==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2026-07-11T17:24:07Z"
-    mac: ENC[AES256_GCM,data:xgtolw3jWQET0XPPYeGD84D5vT+lV4vtFR3m7WQ8HLLQz/kFQbaU0xHlX+s7qeVftgyUdEu2RxAS4jfhu7kMhAZqm4WTaRVLeTol//pATmZuPUMzNaUBRqzueMM9UgTDR8HxoP6Uw5aJH/mYuUV7pmhWHIGwcR2VcUdiFnTlZLY=,iv:yBJPj77bagG9a7a6pETGOJPqBB7Y1CIZMKUzZgwG/F0=,tag:H2IvvHCvtW6A4+7+xvLpxg==,type:str]
+    lastmodified: "2026-07-11T21:54:32Z"
+    mac: ENC[AES256_GCM,data:Ln+Zvpi9YYypspKFMsM9ZeP7iEsAQM/0kSa5qIceSCHPDIly/nWs5154c8mtnh1W15mSsegt81S6dzNwmpGZZihe6gKRAUpJ7npDsoGzh/vUmXXmLiEwyRSUMIMu4rdWgywYW7r/X4dJdYEYY1JrsI0HWFh0c87etl++DPbyg90=,iv:liHe2CkbYv8SFF06be9Vrtep+o6Gkxwe3Sfb+v5OGjo=,tag:AaSxHcrpL2H0eJdai63kjg==,type:str]
     pgp:
-        - created_at: "2026-07-11T17:24:06Z"
+        - created_at: "2026-07-11T21:54:32Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0dSZMvnEisuAQ/9FgLENWv1FDG5P0hVg9Rjmw09ZHSR2IEik0zbS5KNRIB9
-            +qXuOCdH7uJGtWnZ23GRTJTJuC91zUqxxPs8EA6+ve5IIVkOTveJyOTKOpy2wGSk
-            2fMTLMK0W2Y0bb0FekCmt3x0vDDayFzYqjYtSC5pfZLaUjjXlu+aI+B7AhIUc+4Q
-            43wiV+ezeP5lFummNRQEtNxIbRmxBKGWG+I10a8J4imgx6JEMam/sJFqTFDnPUdH
-            +WT+KaTDV/N4NcYJWqeGwJQDmwNi2/kXFLU+dQhNLZJ/ccK2LiFzgXAhUvQWddm7
-            lU1GJmlatjVeI2d3YZhTJK7gWIlUWi/fMD4l6aK0h9mFiwPmD2PXcaWAEegYkJYb
-            zbKDl4BkIKS2fa0Aatbg60VX/Z6v0mDXu1whXOzgGZWsr/eEWgi0Id2V3T0kW1ch
-            BlADutR7git51k6gOkAfIRvrUkBK3M+HNqur09vjlNms11IH4DoqLiruXR2OYwuX
-            A2dtjY2boyAE2Xv5hOFTHskfrkc1DfMRWIusNwyuu5xQzi1P6KwBozDJef5A+y5h
-            D6D4Dh0CeNizJnI9GGn7CSmQFS8C8fukJwLjdimIzMfTEGbsmCH447RU7x2VNg1q
-            l2BvkgMt46RCd0YZpgiTYGUKwo+LS7c1DxzeEJqXi0wGHgM2IIh997IZBoNJox/S
-            XAH4uzvE0G+iFN+HaktoKlDgVeIMHlCXcJbuNVb5M8/Wk6B+63/P+YLdIA+lbql6
-            vjmGwbI9D+DrI+GQpok/YKUCF5j2WAEaVyu0JQUFlaBSbXzgs2on3/jUJ3CE
-            =hVb+
+            hQIMA0dSZMvnEisuAQ//fWattHDY+UP/x1QrIxAzG3zuReiwyiyOCLTM3ux79IvO
+            GZQ4AYK4ZlWL3G42s5necAZQp6LE5vUVmBbAKH9sPGN/GygSTIvwv54fIl/6TEiy
+            SauFhtG1DCcrXYde9+ubDhBQNhtsd/942VMLD5BDkby+IT+Wod5q92LgQxbTjM3e
+            V8nNBG428X7tAT9snbt79Z7PKtfKWKtYL77USmTAkZKpRACAKs/UOBDNoX1tL3Kn
+            YTpq5mWl6nAVJwhBMUdhYfHEjp4mXBMVO+CvYQKxt5+yKXBvP7APUZQgtRnlsiMk
+            IZRorLUPxWYRvMcWnx61nz+af7ESsZCdKX+624jDettaABT7h7visDaJlE8HP5/p
+            vRVS39a3sEMTvJf8QJFod3RRNHv0+G4O1T0g+0G8hCvM5rtILApi28lH4uosvgg7
+            w/RdiGO8YCpHAlHMgeyfU1otVcB2g+WrC22jZR9+h9E87GdNswsKnH6JVv5HJ8Ix
+            XWS61wT8YPy2sARYgeAN0dYrEvgIUrLucAJTunEVko8PanCnyuWDo1t+iCWOlpzn
+            aRih1Rj+rAyIZH77tvenk8uKFRL8GQKCPCbM0AWR0oJe9z0A9Udz71R0LwZhfTaH
+            fQdlqDSRzvv5ZeE7lbXgxTM5C8KUetgmc1JoASCTBLc26e7LxMFHtspyLD5L79PS
+            XgGc/YlOTo3CnySYcvw3MOSmncv8ezXN9pADixHQrEP9gYZ2U0pMriwgY+xoOLNm
+            OovwQx4Ed7FtizKpPFfoRqGz8ViavAMDaG5riXW2klmqufSqAfnFZehM2FOg0QM=
+            =fusP
             -----END PGP MESSAGE-----
           fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
-        - created_at: "2026-07-11T17:24:06Z"
+        - created_at: "2026-07-11T21:54:32Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMAxbwxdi5IniFARAAul31qqvXgJSLnz8ZanyZ5PqascU4G0kSwib1hlqIAEUn
-            wGzg5YpZdnjgK/WMT/CDo/PspCP+NVkPqMBBgRTf+Y9m14a1n0Wz7Ev3q7jLyF/F
-            keB1fIlqt7ZNkoU/g125GqdEO6mPGWiV+Ax/MWLM9qINISAkXf8IpiO04+OHUec1
-            qb6YT5wht5wQrXlgvUqh3BKwtoAFvOu//SocOPqm96JLDVDIpj80y/q2NNlFCPI/
-            P6QpNj/GgPNU5fYUeDK/8VJ33SgclohV00yGXYRVyN/hblSMgS5XrZtpR+i3sBo5
-            yJimuiHk855fwkFK0y8W+g2XbdNjLaReS6IJgiSmtrbj9+ANKSNSS8xzkzYJMDIo
-            kcL9u3WihSYwIQ/MiIrH/TyfYbWIN4dMby+nFVKIxdHLfivYwXSz5r40dRYOW1ax
-            2dfFM/dTQJsQpaoq2j2hUUNx9GO83y1lsQGYCF3De5E2em6J7JBYozOjSF1zv0pz
-            Jnf/P2atXliJSbMPo+ESzKjhSdQQ284V4CMcTbTISWCSNq9G1TuI5lOmMFA4zFPO
-            geLdDWtvL7tqZPa8M1aGDxjO2uVQGwrRAwghs4g0M5AuB4TJLcDkpYDMNY5qgO7b
-            7r81gcQqleqgoztOCKs/s2u+us9i82cIlxSDfoguz4Rk8es1obD0C+MmNg+MV1nS
-            XAHHXGsgBnP7dQ9WDB5H0gSv9JRwauNyp8/FKv2Ipx0hYJYGu5y8spHDNSbzjdv1
-            CqjilrATcEe4on1rZzsirdan+R57Jt3SyztPxMxi0OzOMU5N1qNUs7HXQVFJ
-            =eUJx
+            hQIMAxbwxdi5IniFARAAsatsDA4ebhl695s9OL3L41yKlcYDiI+1Vo+6yjP6h/w2
+            TBZXdIUB3q/P+NzdiwIdx0Mc6w3osO4thy7NOlHU1nBqfrrw5Gkv63Efe4Yn0KfJ
+            5JbjnTbJGb2oiC999XT420nOxr1ExAE/HS/dbKt6fS7MlhDHka7+lNTupLUCaPA+
+            7hCUp0A/MGyvIeaspyUvOcQx99XB7uRa/JkumDnEiUpdz4X3jJKVNc+wmeTdQYEw
+            Jk7TO35s3k534WDfXNnKPDMGEu92q+cx8Rjc+uLlWbTrbQxmqvUaaopQFTmRUQ02
+            djG3XANPmV+b4YhLLQsML16wmpgEEnEV69wM85jFDWw0zPLWnGcEr0r/KFub3ZhT
+            CbXUJ8MrbWVnJhnfe0qAg9fo6emENc8iHTA1S6xABS+iaUoXyY6IK0O1GvUgceEb
+            fF/eBW0hcnViugcKoGOGNS7dOZFg7gH98JQ2xr+I6nS7EA/idjcc81hbXPIx1VcP
+            ohpjBiw3U3ffFm63oFb8fSGrw8NW2oa0rWC7mtQKdixwNKTQ9BmINC4aPoQV9QR0
+            jc6I75n2HT9CBJHtSMlCTGZ4c1M+5KxKi1peKVNdfxyZ6laRiIRkvcjr59mmjn6r
+            Wp+iDy5RZngPpBO+aemYygp4XF7IH/0mddP70IZGyLCvawHmwED8Dqdj4sSonnTS
+            XgEfGkqvl8tstS5iArW59JIlz1I6npfC/YZTf00L6eKPbDkEhlfju5X46I/OUake
+            oteCPRtlL+dhFLmFPG+LQh4GKWrRTz7q+DLa/rcQtvzfVFdb/t4tRiBGY+GRdkg=
+            =ev9Z
             -----END PGP MESSAGE-----
           fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
     encrypted_regex: ^(data|stringData)$


### PR DESCRIPTION
Unsuspends the proton-mirror CronJob and fills the mirror config for the first user. Entries still awaiting credentials are parked in a `mirrors-pending.json` key (not mounted) so partial config can't fail the job.

Pre-flight checks done: ICS feed returns 200, CalDAV auth + target collection return 207, namespace egress unrestricted (ingress-only netpols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjQot9dfgHNca9VsSiYmX