### PR TITLE
feat(monitoring): scrape pfSense node_exporter

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -285,6 +285,14 @@ spec:
                   - ${NFS_SERVER}:9134
                 labels:
                   instance: shodan
+          # pfSense router — official node_exporter package, scraped the
+          # same static-config way as the other non-cluster hosts.
+          - job_name: node-pfsense
+            static_configs:
+              - targets:
+                  - ${PFSENSE_HOST}:9100
+                labels:
+                  instance: pfsense
         # retentionSize is the real safety valve on a fixed-size disk: Prometheus
         # GCs by size before it can ever hit ENOSPC (a full 10Gi SSD PVC wedged
         # the TSDB 2026-06-20 → blind 5d). Keep it comfortably under the PVC size.


### PR DESCRIPTION
Adds a static scrape job for the router's node_exporter package (:9100), following the same pattern as the other non-cluster hosts. Uses the existing `${PFSENSE_HOST}` substitution var.

Target will show DOWN until the firewall pass rule for the monitoring subnet is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjQot9dfgHNca9VsSiYmX