### PR TITLE
feat(radicale): mealie meal-plan mirror into the family calendar

### DIFF
--- a/cluster/apps/radicale/kustomization.yaml
+++ b/cluster/apps/radicale/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./namespace.yaml
   - ./radicale/ks.yaml
   - ./proton-mirror/ks.yaml
+  - ./mealie-mirror/ks.yaml
   - ./netpol

--- a/cluster/apps/radicale/mealie-mirror/app/helm-release.yaml
+++ b/cluster/apps/radicale/mealie-mirror/app/helm-release.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mealie-mirror
+  namespace: radicale
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  values:
+    controllers:
+      mealie-mirror:
+        type: cronjob
+        cronjob:
+          schedule: "23 * * * *"
+          # suspended until the config.json secret holds a real Mealie API
+          # token; flip to false to go live
+          suspend: true
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 2
+        containers:
+          app:
+            image:
+              repository: python
+              tag: 3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280
+            command: ["python", "/app/mealie_mirror.py"]
+            env:
+              RADICALE_URL: http://radicale.radicale.svc.cluster.local:5232
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    persistence:
+      script:
+        type: configMap
+        name: mealie-mirror-configmap
+        globalMounts:
+          - path: /app/mealie_mirror.py
+            subPath: mealie_mirror.py
+            readOnly: true
+      config:
+        type: secret
+        name: mealie-mirror-secret
+        globalMounts:
+          - path: /config/config.json
+            subPath: config.json
+            readOnly: true

--- a/cluster/apps/radicale/mealie-mirror/app/kustomization.yaml
+++ b/cluster/apps/radicale/mealie-mirror/app/kustomization.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: radicale
+resources:
+  - ./secret.sops.yaml
+  - ./helm-release.yaml
+configMapGenerator:
+  - name: mealie-mirror-configmap
+    files:
+      - mealie_mirror.py=./resources/mealie_mirror.py
+    options:
+      disableNameSuffixHash: true

--- a/cluster/apps/radicale/mealie-mirror/app/resources/mealie_mirror.py
+++ b/cluster/apps/radicale/mealie-mirror/app/resources/mealie_mirror.py
@@ -1,0 +1,236 @@
+"""Mirror the Mealie meal plan into a Radicale calendar.
+
+Mealie owns the household meal plan; this job projects it onto the shared
+family calendar so meals show up in everyone's phone calendar app next to
+real events. Stateless: every event the mirror writes carries an
+X-MEALIE-MIRROR property with a content hash, so each run can identify its
+own events, update changed ones, and delete entries removed from the plan —
+without ever touching events created directly in Radicale.
+
+Only plan entries inside the sync window (WINDOW_PAST days back to
+WINDOW_FUTURE days ahead) are managed; mirrored events older than the
+window are left in place as meal history.
+
+Config: config.json — {"mealie_url", "mealie_token", "user", "password",
+"collection"}; MIRROR_CONFIG, RADICALE_URL and DRY_RUN come from the
+environment.
+"""
+
+import base64
+import datetime
+import hashlib
+import json
+import os
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+
+RADICALE_URL = os.environ.get(
+    "RADICALE_URL", "http://radicale.radicale.svc.cluster.local:5232"
+)
+DRY_RUN = os.environ.get("DRY_RUN", "") == "1"
+MARKER = "X-MEALIE-MIRROR"
+WINDOW_PAST = int(os.environ.get("WINDOW_PAST", "7"))
+WINDOW_FUTURE = int(os.environ.get("WINDOW_FUTURE", "30"))
+
+
+def http(method, url, auth=None, body=None, headers=None):
+    """One-shot HTTP request; returns (status, body bytes)."""
+    req = urllib.request.Request(url, method=method, data=body)
+    if auth is not None:
+        token = base64.b64encode(f"{auth[0]}:{auth[1]}".encode()).decode()
+        req.add_header("Authorization", f"Basic {token}")
+    for key, value in (headers or {}).items():
+        req.add_header(key, value)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as err:
+        return err.code, err.read()
+
+
+def unfold(text):
+    """Unfold RFC 5545 folded lines."""
+    out = []
+    for line in text.replace("\r\n", "\n").split("\n"):
+        if line[:1] in (" ", "\t") and out:
+            out[-1] += line[1:]
+        else:
+            out.append(line)
+    return out
+
+
+def prop_value(block, name):
+    """Value of the first property `name` in an unfolded component block."""
+    for line in block:
+        upper = line.upper()
+        if upper.startswith(name.upper() + ":") or upper.startswith(name.upper() + ";"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def ical_escape(text):
+    """Escape a value for an iCalendar TEXT property."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\n", "\\n")
+    )
+
+
+def fetch_plan(config, start, end):
+    """Fetch meal plan entries -> {uid: (hash, vevent lines, date)}."""
+    url = (
+        f"{config['mealie_url']}/api/households/mealplans"
+        f"?start_date={start.isoformat()}&end_date={end.isoformat()}&perPage=-1"
+    )
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {config['mealie_token']}"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        payload = json.load(resp)
+    events = {}
+    for entry in payload.get("items", []):
+        day = datetime.date.fromisoformat(entry["date"])
+        name = (entry.get("recipe") or {}).get("name") or entry.get("title") or "?"
+        meal = (entry.get("entryType") or "dinner").capitalize()
+        uid = f"mealie-{entry['id']}@mealie-mirror"
+        lines = [
+            "BEGIN:VEVENT",
+            f"UID:{uid}",
+            f"DTSTART;VALUE=DATE:{day.strftime('%Y%m%d')}",
+            f"DTEND;VALUE=DATE:{(day + datetime.timedelta(days=1)).strftime('%Y%m%d')}",
+            f"SUMMARY:{ical_escape(f'{meal}: {name}')}",
+            "TRANSP:TRANSPARENT",
+            "END:VEVENT",
+        ]
+        note = entry.get("text") or ""
+        if note:
+            lines.insert(-1, f"DESCRIPTION:{ical_escape(note)}")
+        digest = hashlib.sha256("\n".join(lines).encode()).hexdigest()[:16]
+        events[uid] = (digest, lines, day)
+    return events
+
+
+def wrap_event(ev_lines, digest):
+    """Wrap one VEVENT into a marked VCALENDAR."""
+    event = list(ev_lines)
+    event.insert(-1, f"{MARKER}:{digest}")
+    body = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//mealie-mirror//EN"]
+    body.extend(event)
+    body.append("END:VCALENDAR")
+    return "\r\n".join(body) + "\r\n"
+
+
+def existing_mirrored(base, auth):
+    """REPORT the collection -> {uid: (href, digest, date)} for mirror-owned items."""
+    report = (
+        '<?xml version="1.0" encoding="utf-8" ?>'
+        '<C:calendar-query xmlns:D="DAV:" '
+        'xmlns:C="urn:ietf:params:xml:ns:caldav">'
+        "<D:prop><C:calendar-data/></D:prop>"
+        '<C:filter><C:comp-filter name="VCALENDAR">'
+        '<C:comp-filter name="VEVENT"/></C:comp-filter></C:filter>'
+        "</C:calendar-query>"
+    )
+    status, body = http(
+        "REPORT",
+        base,
+        auth,
+        report.encode(),
+        {"Content-Type": "application/xml", "Depth": "1"},
+    )
+    if status != 207:
+        raise RuntimeError(f"REPORT {base} -> {status}")
+    out = {}
+    namespaces = {"D": "DAV:", "C": "urn:ietf:params:xml:ns:caldav"}
+    for resp in ET.fromstring(body).findall("D:response", namespaces):
+        href = resp.findtext("D:href", namespaces=namespaces)
+        data = resp.findtext(".//C:calendar-data", namespaces=namespaces) or ""
+        lines = unfold(data)
+        digest = prop_value(lines, MARKER)
+        uid = prop_value(lines, "UID")
+        raw_start = (prop_value(lines, "DTSTART") or "").split("T")[0]
+        try:
+            day = datetime.datetime.strptime(raw_start, "%Y%m%d").date()
+        except ValueError:
+            day = None
+        if digest and uid:
+            out[uid] = (href, digest, day)
+    return out
+
+
+def upsert_events(base, auth, events, mirrored):
+    """PUT new/changed plan events; returns (created, updated, kept)."""
+    created = updated = kept = 0
+    for uid, (digest, event, _) in events.items():
+        if uid in mirrored and mirrored[uid][1] == digest:
+            kept += 1
+            continue
+        action = "update" if uid in mirrored else "create"
+        safe = hashlib.sha256(uid.encode()).hexdigest()[:32]
+        if DRY_RUN:
+            print(f"DRY: {action} {uid}")
+        else:
+            status, _ = http(
+                "PUT",
+                f"{base}mealie-{safe}.ics",
+                auth,
+                wrap_event(event, digest).encode(),
+                {"Content-Type": "text/calendar"},
+            )
+            if status not in (200, 201, 204):
+                print(f"WARN: PUT {uid} -> {status}", file=sys.stderr)
+                continue
+        created += action == "create"
+        updated += action == "update"
+    return created, updated, kept
+
+
+def delete_removed(auth, events, mirrored, start):
+    """DELETE mirror-owned events dropped from the plan; returns count.
+
+    Events dated before the sync window are kept as meal history — the
+    windowed fetch can't see them, so their absence proves nothing.
+    """
+    deleted = 0
+    for uid, (href, _, day) in mirrored.items():
+        if uid in events:
+            continue
+        if day is not None and day < start:
+            continue
+        if DRY_RUN:
+            print(f"DRY: delete {uid}")
+        else:
+            status, _ = http("DELETE", f"{RADICALE_URL}{href}", auth)
+            if status not in (200, 204):
+                print(f"WARN: DELETE {uid} -> {status}", file=sys.stderr)
+                continue
+        deleted += 1
+    return deleted
+
+
+def main():
+    """Sync the meal plan window into the configured collection."""
+    path = os.environ.get("MIRROR_CONFIG", "/config/config.json")
+    with open(path, encoding="utf-8") as handle:
+        config = json.load(handle)
+    base = f"{RADICALE_URL}{config['collection']}"
+    auth = (config["user"], config["password"])
+    today = datetime.date.today()
+    start = today - datetime.timedelta(days=WINDOW_PAST)
+    end = today + datetime.timedelta(days=WINDOW_FUTURE)
+
+    events = fetch_plan(config, start, end)
+    mirrored = existing_mirrored(base, auth)
+    created, updated, kept = upsert_events(base, auth, events, mirrored)
+    deleted = delete_removed(auth, events, mirrored, start)
+    print(
+        f"{config['collection']}: {len(events)} planned meals | "
+        f"+{created} ~{updated} -{deleted} ={kept}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cluster/apps/radicale/mealie-mirror/app/secret.sops.yaml
+++ b/cluster/apps/radicale/mealie-mirror/app/secret.sops.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mealie-mirror-secret
+    namespace: radicale
+stringData:
+    config.json: ENC[AES256_GCM,data:y7F/tL2VwUvdvBAgNl07mmyBYYBbJziA7Igut872CVO79MQn9znoIXjuWcSCsK2pWnygAq8iY1a6qfSoAutdWEiU9kCNsKoWaqV0WUu82UkOXELW52N4/OmnXN+VRrDVOp4RXQe3iio5RdfJ2NY358wOU1gtcIAqhAwWWf3/KXXGe5EPhcjB7IYSdi+d0iTxJmqTBxA2iuXVwx/VebtANG9sE9LTCH01C5GgN+d0z6S3qBynFs7NnANqoigw,iv:VRGZOo4foroUpyMXR7hdzXu+qmx4SgTd2qpOSwFbgyc=,tag:9treh2rBjKDS4/m7qoLrpw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-07-11T22:21:43Z"
+    mac: ENC[AES256_GCM,data:QfDzpmm37m8IbF0/payHpF8cOEljO3cuR1izWQQBqBm7gWGRNMMCa9yDWzWXSh0fIhYTcEmEdB8fQLzi3W/6pTyP+1/orG/tIsnYyPjw8lLfyegoPP5DI+DSPx7+8L82yGu7sp43CRJMSBeYh4jAdaBY70d0kaXSu7rcl3fzJpU=,iv:UE6O9T3RxHMTjT8w7UIQ/jVYYjr6YWr7VD+BGYRf1JI=,tag:O1UX+2bvS2olAy5KgDCHpg==,type:str]
+    pgp:
+        - created_at: "2026-07-11T22:21:42Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0dSZMvnEisuAQ/8DD5SodXBB0+yzbJjysOiEv+3MejF8zp61iQo2BOgEGDq
+            o9fVUt3F1N1JrEKhDTC4QRE5l6JJxCdFO0jnWoI43DvrXMuv6yL8Ih6WOETbo7bL
+            t7Tx6Q3ov4xFHZ14Ji3yqtC4x/VcmCu6EUImv3EjjV4ur/pbvKE93sbOaKF1A7Mh
+            J19sJMyygmi+lTpV/36sOn0k3MpxEh1i0AN6ugoM4SNbKrjEf+/JgJsA/fOfFPh3
+            LoMFg+OjdDz2k6puuJMn//mZaQ+GV0bvFgIpLkIiUT0E/3b6f0DPZ7JpP3VvH28F
+            z2armdXwlprCNEV3VsgFufcLJqBkZOQCH4qV9KIDD9OmdWpAQWc+MXTjMKVrguRv
+            UEm/emyq47iDzm9vVGxjvtPgE7gIbqUyPHqe7gdXDsxgKdcVWNCzUVXgJ51fdWZc
+            ZXV1Kpb7RH35FPJ8epRAK1cEHd16RKIMms/2xJ02piezjZb5nCsCY1ylD50k+8al
+            XOevxfpnNamiJZcLJXIUCljgYZnU58fVskirkzoadSqwWP8mEyQBLzeEfLs2GpO3
+            lAVcRuJyCKaX78vARRCLQ2XEDynmdDNU97mOF5YSKKEmfobBm+ylkYnemRyT20Ns
+            xX+mpGIVVGyMRo0j4nMA1GPyeI9J67BOisA5m+UES5YZqrvapAXKCpiebH3i+6PS
+            XgFoTeYLgpLk6YJ0KhkrwLrRBlv1Z30kCGMUXn2kEerB9HCfvMf2gHEiZecyhBu4
+            llBGQN3b6C6qNiiQYbSXgbcG26TMbCVUGCpoyy9IzQ0NfqOJlrZ3wZsqPl6J0QY=
+            =dQvg
+            -----END PGP MESSAGE-----
+          fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
+        - created_at: "2026-07-11T22:21:42Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAxbwxdi5IniFARAAnV2DNOjuHpPwK7wqJqvPco/+HAleO6/MKhX4Gp65gMky
+            Ukq9hQ+zOPVlvCjzl4RBdLYmWH91q/sol5Nac//WYHwyHE2QqlXOe6nJ7QCzfvxl
+            qP7L6pBGzvW9X4hh47uUgNOV82c4cyeGAukNbQFAhjop9otOPh+nIM3PYipj6ZR8
+            2yjvsjkKktRHLPqL36z/SlGEHWewWINMUAhGv4STMN/7ip+eD/u6KFPmczd/gimE
+            oC37Kx73i11uvXldNDaE/UqhBlH3rX/t4gRXkOV9COD01EWBqeFtsON766YPIfaD
+            JyDH0dIZj/XxRfY0AQ2dcFADuf9Pdpt70LcZnCOcH/thlPcFoCSvYajwqWuO5rO6
+            guGkE2La5kITOWeSaxHtwRwZuUATxnlMf7rvxXjpEboFhX6k2vxBTfTUSKN5Qw2P
+            exsxlQU9jCb8a3xHUcgR5S6lodkpifzFpW/ob7VhP4tOnEt6zbBQrp32ZztbnfU9
+            T3HAvE0ijhHD3vEq95wvvb54VIVz4126czrR/xWB1Xr78snau0UOBAerWNhoa86K
+            LHLnZBf9aGZJ5WhAdMKlLAd4qERMyZ/T2X2bFWfjDRlwQ4l+RWUXf4NlqR5nXcQv
+            kOLefWyfxV8aI6Jo4p8VwKSFgbvbQyn6RGCbuBZlPsrvr/C54CQ8B0ccARQmMZHS
+            XgE2VFCpUTsp0HgC7iU9j2BlRwvYZMXCzy5eXLMch3dpbXpxfWnciD82hvSGRZaz
+            MafP/N39QFxAUpoXs+GpHEasbKGIKEw799kBjzcU2kYPcLJsiaOCo+t8TtL6TG0=
+            =hLEH
+            -----END PGP MESSAGE-----
+          fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/cluster/apps/radicale/mealie-mirror/ks.yaml
+++ b/cluster/apps/radicale/mealie-mirror/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-mealie-mirror
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/radicale/mealie-mirror/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Projects the Mealie meal plan onto the shared family CalDAV calendar so meals appear in phone calendar apps alongside real events.

- `mealie_mirror.py`: stdlib-only, same content-hash upsert/delete pattern as proton-mirror; distinct `X-MEALIE-MIRROR` marker and href prefix so the two mirrors can never fight; sync window −7d..+30d with past mirrored events kept as history
- Hourly CronJob in the radicale namespace (Mealie reached via its ingress, Radicale via the in-namespace service — no netpol changes needed)
- Ships `suspend: true` until the Mealie API token lands in the secret

Lifecycle-tested against a local Radicale + fake Mealie API: create / idempotent / edit / windowed-delete-with-history / directly-created-events-untouched all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjQot9dfgHNca9VsSiYmX