### PR TITLE
feat(homepage): serve hajimari's old home hostname too

### DIFF
--- a/cluster/apps/homepage/homepage/app/helm-release.yaml
+++ b/cluster/apps/homepage/homepage/app/helm-release.yaml
@@ -69,12 +69,16 @@ spec:
           gethomepage.dev/enabled: "false"
         hosts:
           - host: &host "apps.${SECRET_DOMAIN}"
-            paths:
+            paths: &paths
               - path: /
                 pathType: Prefix
+          # hajimari's old address, kept alive out of muscle memory
+          - host: &homeHost "home.${SECRET_DOMAIN}"
+            paths: *paths
         tls:
           - hosts:
               - *host
+              - *homeHost
     persistence:
       config:
         type: configMap


### PR DESCRIPTION
Adds the retired dashboard's hostname as a second ingress host on Homepage so bookmarks and muscle memory keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjQot9dfgHNca9VsSiYmX