### PR TITLE
fix(monitoring): match pfSense scrape job to dashboard conventions

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -296,13 +296,14 @@ spec:
                 labels:
                   instance: shodan
           # pfSense router — official node_exporter package, scraped the
-          # same static-config way as the other non-cluster hosts.
-          - job_name: node-pfsense
+          # same static-config way as the other non-cluster hosts. The
+          # grafana.com 11491 board needs job=~"pfsense.*" and a default
+          # host:port instance label (its variables split on the colon),
+          # so no instance override here.
+          - job_name: pfsense
             static_configs:
               - targets:
                   - ${PFSENSE_HOST}:9100
-                labels:
-                  instance: pfsense
         # retentionSize is the real safety valve on a fixed-size disk: Prometheus
         # GCs by size before it can ever hit ENOSPC (a full 10Gi SSD PVC wedged
         # the TSDB 2026-06-20 → blind 5d). Keep it comfortably under the PVC size.


### PR DESCRIPTION
Dashboard 11491's variables want `job=~\"pfsense.*\"` and a default host:port instance label (they split on the colon). Renames the job and drops the instance override so the host dropdown populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjQot9dfgHNca9VsSiYmX