### PR TITLE
fix(monitoring): scrape pfSense at 15s for the dashboard's rate windows

### DIFF
--- a/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/app/helm-release.yaml
@@ -301,6 +301,9 @@ spec:
           # host:port instance label (its variables split on the colon),
           # so no instance override here.
           - job_name: pfsense
+            # the 11491 board rates over 30s windows (some hardcoded), which
+            # needs >1 sample per window — scrape faster than the 30s global
+            scrape_interval: 15s
             static_configs:
               - targets:
                   - ${PFSENSE_HOST}:9100


### PR DESCRIPTION
Dashboard 11491 rates over 30s windows (some hardcoded in CPU panels) which need more than one sample per window; the global scrape interval is 30s. Per-job 15s interval fixes bandwidth/CPU panels at their defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjQot9dfgHNca9VsSiYmX