### PR TITLE
feat(monitoring): alert on Music Assistant Apple Music token expiry

### DIFF
--- a/cluster/apps/monitoring/loki/app/alerting-rules.yaml
+++ b/cluster/apps/monitoring/loki/app/alerting-rules.yaml
@@ -36,3 +36,17 @@ data:
               severity: warning
             annotations:
               summary: "Failed sudo attempt on {{ $labels.host }}"
+      - name: service-health
+        rules:
+          # Apple expires Music Assistant's user token ~6-monthly; every API
+          # call then 403s (library syncs + playback) while voice playback
+          # fails claiming success. Symptom-based: fires on the periodic
+          # sync failures.
+          - alert: MusicAssistantAppleTokenExpired
+            expr: |
+              sum(count_over_time({namespace="home", pod=~"music-assistant.*"} |= `api.music.apple.com` |= `403` [6h])) > 2
+            for: 0m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Music Assistant Apple Music calls are returning 403 — user token likely expired; re-authenticate in MA settings → providers"


### PR DESCRIPTION
Loki ruler rule (new `service-health` group): fires when Music Assistant logs 403s against api.music.apple.com — the symptom of the ~6-monthly Apple user-token expiry that silently kills voice music playback. Condition is currently true, so this live-fire tests itself on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PjQot9dfgHNca9VsSiYmX