### PR TITLE
fix(vllm): give router startupProbe enough budget to bind, pin image

### DIFF
--- a/cluster/apps/ai/vllm/app/helm-release.yaml
+++ b/cluster/apps/ai/vllm/app/helm-release.yaml
@@ -351,6 +351,30 @@ spec:
 
     routerSpec:
       enableRouter: true
+      # The router is LMCache's production-stack router (lmcache/lmstack-router),
+      # a SEPARATE project from the vLLM engine (vllm/vllm-openai) — its version
+      # tracks the vllm-stack chart (0.1.11), NOT the engine tag (v0.24.0 above).
+      # Chart default is tag `latest` + imagePullPolicy Always, so every pod start
+      # re-pulls from Docker Hub (slow cold-start, e.g. after a power outage) and
+      # drifts from git. v0.1.11 is the exact digest `latest` pointed at on
+      # 2026-06-25, so this pin is a no-op on behavior; IfNotPresent lets it start
+      # from the node's local image cache.
+      repository: lmcache/lmstack-router
+      tag: v0.1.11@sha256:936084b8dc78c9e9cd837b8a54242f414c0948c82dcd9a8109c19de229f3eb23
+      imagePullPolicy: IfNotPresent
+      # Chart default startupProbe (delay 5s + 3 × 5s) gives the container ~15s to
+      # bind :8000. Measured cold start after a node reboot: 20.5s of silence for
+      # the python import phase, then it binds. It misses by one probe interval and
+      # crashloops — on a warm node it squeaked in, which is why this only shows up
+      # after kured cycles a node. 12 failures = ~65s budget, plenty of headroom
+      # without masking a genuinely wedged router (liveness still catches that).
+      startupProbe:
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        failureThreshold: 12
+        httpGet:
+          path: /health
+          port: router-port
       ingress:
         enabled: true
         className: traefik


### PR DESCRIPTION
## Problem

The vLLM router has been crashlooping since a node reboot (13 restarts). It is not a GPU or engine problem — the engine is serving fine and the router discovers it successfully on every attempt before being killed.

## Root cause

The chart's default `startupProbe` allows `initialDelaySeconds: 5` + `failureThreshold: 3` × `periodSeconds: 5` ≈ **15s** for the container to serve `/health`.

Measured cold start:

| event | offset |
|---|---|
| container `startedAt` | t=0 |
| first log line (python import phase ends) | **t=20.5s** |
| binds `:8000` | t=20.6s |

It misses the deadline by about one probe interval, gets SIGKILLed, and repeats. On a warm node the import phase fit inside the budget, which is why this only surfaced once a node was cycled and the page cache was cold.

## Fix

- `failureThreshold: 12` → ~65s budget. `livenessProbe` is deliberately untouched, so a genuinely wedged router is still caught; this only stops us killing a container that is starting normally but slowly.
- Pin the router image. Chart default is `latest` + `imagePullPolicy: Always`, so every pod start re-pulls a 5.4 GB image and drifts from git. `v0.1.11` is the exact digest `latest` currently resolves to, so the pin is a **no-op on behavior today**; `IfNotPresent` lets restarts use the node's local cache.

## Verification

- Value keys checked against `helm show values vllm-stack --version 0.1.11`: `routerSpec.repository`, `tag`, `imagePullPolicy`, `startupProbe` are all real chart keys with the shape used here.
- Full local `helm template` render was **not** completed — the chart has templates that nil-pointer when values are extracted outside Flux's context (`keda`, `ray`, `pdb`). Verification is therefore key-level; Flux's own dry-run is the real check.
- Pre-commit hooks pass: yamllint, prettier, kubeconform, kustomize build smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXKXvcbw1CL1zLcjSeimeC