### PR TITLE
retrosync: bump image v0.3.0 -> v0.3.1

### DIFF
--- a/cluster/apps/retrosync/retrosync/app/helm-release.yaml
+++ b/cluster/apps/retrosync/retrosync/app/helm-release.yaml
@@ -51,7 +51,7 @@ spec:
           bootstrap-admin:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.3.0
+              tag: v0.3.1
             args:
               ["user", "set", "alex", "--display", "Alex", "--role", "admin"]
             env:
@@ -69,7 +69,7 @@ spec:
           app:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.3.0
+              tag: v0.3.1
             args: ["serve"]
             env:
               # CNPG's auto-generated app secret ships a ready-made connection


### PR DESCRIPTION
RetroSync v0.3.1: publishes save files 0644 instead of the 0600 `os.CreateTemp` assigned. A 0600 save can be unreadable to the emulator or syncthing daemon on devices that sync permissions, which fails silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W26iLF2dHjP9jbLCNsUdeE