### PR TITLE
retrosync: bump image v0.3.1 -> v0.4.0

### DIFF
--- a/cluster/apps/retrosync/retrosync/app/helm-release.yaml
+++ b/cluster/apps/retrosync/retrosync/app/helm-release.yaml
@@ -51,7 +51,7 @@ spec:
           bootstrap-admin:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.3.1
+              tag: v0.4.0
             args:
               ["user", "set", "alex", "--display", "Alex", "--role", "admin"]
             env:
@@ -69,7 +69,7 @@ spec:
           app:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.3.1
+              tag: v0.4.0
             args: ["serve"]
             env:
               # CNPG's auto-generated app secret ships a ready-made connection


### PR DESCRIPTION
RetroSync v0.4.0 — fixes silent save divergence (RetroSync#33).

RetroSync stamped the source file's mtime on fan-out; since save files are a fixed size, a colliding mtime made the new bytes invisible to both syncthing's scanner and RetroSync's own poll — permanently, with every status endpoint reporting green. Published mtimes are now always strictly newer than the destination's previous one, and `Poll` periodically verifies past the stat gate to catch collisions caused by other writers.

Also: clearer save-vs-add button wording in the sync UI. Verified end to end in a container against the real image before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W26iLF2dHjP9jbLCNsUdeE