### PR TITLE
retrosync: bump image v0.4.0 -> v0.4.1

### DIFF
--- a/cluster/apps/retrosync/retrosync/app/helm-release.yaml
+++ b/cluster/apps/retrosync/retrosync/app/helm-release.yaml
@@ -51,7 +51,7 @@ spec:
           bootstrap-admin:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.4.0
+              tag: v0.4.1
             args:
               ["user", "set", "alex", "--display", "Alex", "--role", "admin"]
             env:
@@ -69,7 +69,7 @@ spec:
           app:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.4.0
+              tag: v0.4.1
             args: ["serve"]
             env:
               # CNPG's auto-generated app secret ships a ready-made connection


### PR DESCRIPTION
Bumps both image pins (the `bootstrap-admin` job and the `app` deployment) from `v0.4.0` to `v0.4.1`.

**What's in v0.4.1** — RetroSync now alters a save file's mtime only when a human made an explicit choice. There are exactly three: initiating a sync, resolving a conflict, and restoring a version. Routine auto-mirror never touches file metadata.

v0.4.0 fixed the underlying bug — a fan-out that writes an identical mtime *and* size is invisible to both syncthing's scanner and RetroSync's own stat gate, so a save silently fails to propagate — but it put the rule inside the filesystem adapter, which cannot tell a one-time adoption from the ten-thousandth routine mirror. So it applied to every write, silently. The policy now lives in the engine, which knows the sync, and intent is passed explicitly rather than inferred from timestamps.

Also in v0.4.1: the trigger narrowed to exact mtime+size equality (v0.4.0's "not strictly newer" fired wherever two devices' clocks disagreed, for no benefit), and every bump is logged. A collision on a *routine* write is deliberately not silently corrected — it logs a warning and publishes verbatim, because in steady state that means content changed while its mtime did not, which deserves a human.

Upstream: https://github.com/a-mcf/RetroSync/pull/38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPDabb1qWZzkWzRfv7KCfm
