### PR TITLE
retrosync: bump image v0.4.1 -> v0.5.0

### DIFF
--- a/cluster/apps/retrosync/retrosync/app/helm-release.yaml
+++ b/cluster/apps/retrosync/retrosync/app/helm-release.yaml
@@ -51,7 +51,7 @@ spec:
           bootstrap-admin:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.4.1
+              tag: v0.5.0
             args:
               ["user", "set", "alex", "--display", "Alex", "--role", "admin"]
             env:
@@ -69,7 +69,7 @@ spec:
           app:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.4.1
+              tag: v0.5.0
             args: ["serve"]
             env:
               # CNPG's auto-generated app secret ships a ready-made connection


### PR DESCRIPTION
Bumps both image pins (the `bootstrap-admin` job and the `app` deployment) from `v0.4.1` to `v0.5.0`.

**What's in v0.5.0** — user management moves into the app.

- **`/users`** (admin-only) — add a person, edit display name and role, reset someone's password, delete an account.
- **`/account`** (any signed-in user) — change your own password, proving the current one first.

Until now the only way to create a user was `retrosync user set` on the CLI, which in the cluster means spinning up a one-off pod just to add someone to the household.

**Guardrails:** the store refuses to delete or demote the last admin, checked inside the write's transaction so two concurrent demotes can't both pass and leave zero. Self-delete is refused, as is deleting someone who still owns devices (with a message naming the count, rather than cascading their devices away). Sessions are revoked on password reset, role change and delete.

**No effect on the bootstrap-admin job.** It passes `--display` and `--role` explicitly. v0.5.0 changes only what happens when those flags are *omitted* — they now leave the existing value alone instead of reapplying the flag default, so that resetting the sole admin's password no longer demotes the account being recovered.

Upstream: https://github.com/a-mcf/RetroSync/pull/39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPDabb1qWZzkWzRfv7KCfm
