### PR TITLE
retrosync: bump image v0.5.0 -> v0.6.0

### DIFF
--- a/cluster/apps/retrosync/retrosync/app/helm-release.yaml
+++ b/cluster/apps/retrosync/retrosync/app/helm-release.yaml
@@ -51,7 +51,7 @@ spec:
           bootstrap-admin:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.5.0
+              tag: v0.6.0
             args:
               ["user", "set", "alex", "--display", "Alex", "--role", "admin"]
             env:
@@ -69,7 +69,7 @@ spec:
           app:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.5.0
+              tag: v0.6.0
             args: ["serve"]
             env:
               # CNPG's auto-generated app secret ships a ready-made connection


### PR DESCRIPTION
Bumps both image pins (the `bootstrap-admin` job and the `app` deployment) from `v0.5.0` to `v0.6.0`.

**What's in v0.6.0** — the UI overhaul.

RetroSync adopts **Pico CSS v2** as its design language: vendored as a plain stylesheet, no build step, semantic-first so the markup carries the meaning (which matters because HTMX swaps that markup by hand). It replaces a homegrown look whose every control was sized for a thumb, on the assumption that syncing would be driven by hand on the device — it isn't, and RetroSync is an admin console driven from a desktop browser. `app.css` drops from 331 lines to 137.

Two information-architecture fixes ride along:

- **A sync's save files are a read-only table until you ask to change them.** Every path used to be a live input with a Save button always present, so the page couldn't show a sync's configuration without also offering to mutate it. Editing now opens a dialog that carries the Browse picker — a scrolling file tree, which is what made the old rows sprawl.
- **Destructive actions are the quietest control on the screen**, inside the disclosure or dialog that owns the thing, rather than filled red buttons on the row. They keep their confirms.

No schema change, no config change, no new environment variables. The `bootstrap-admin` job is untouched.

Upstream: https://github.com/a-mcf/RetroSync/pull/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPDabb1qWZzkWzRfv7KCfm
