### PR TITLE
retrosync: bump image v0.6.0 -> v0.7.0

### DIFF
--- a/cluster/apps/retrosync/retrosync/app/helm-release.yaml
+++ b/cluster/apps/retrosync/retrosync/app/helm-release.yaml
@@ -51,7 +51,7 @@ spec:
           bootstrap-admin:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.6.0
+              tag: v0.7.0
             args:
               ["user", "set", "alex", "--display", "Alex", "--role", "admin"]
             env:
@@ -69,7 +69,7 @@ spec:
           app:
             image:
               repository: ghcr.io/a-mcf/retrosync
-              tag: v0.6.0
+              tag: v0.7.0
             args: ["serve"]
             env:
               # CNPG's auto-generated app secret ships a ready-made connection


### PR DESCRIPTION
Bumps both image pins (the `bootstrap-admin` job and the `app` deployment) from `v0.6.0` to `v0.7.0`.

**What's in v0.7.0** — a settings page.

The top nav had grown to five destinations plus an identity block, with "Account" sitting as a peer of "Devices" — a personal preference alongside registry administration.

`/settings` now holds your own account (identity, change-your-own-password) and, for an admin, a link through to People with a count of who's registered. The nav drops to **Discover / Syncs / Devices / Settings**. `/account` 301s to `/settings`, preserving the query string, so bookmarks and the post-password-change confirmation keep working.

Internally the eight per-page `<head>`/`<nav>` blocks collapse into two shared partials — which is what makes a future dark/light preference a one-line change rather than an eight-file one.

Reviewed by the reviewer and auditor agents before merge. The auditor verified by sweeping every route registration that hiding admin destinations from a non-admin is cosmetic only — each is independently `requireAdmin`-gated.

No schema change, no config change, no new environment variables. The `bootstrap-admin` job is untouched.

Upstream: https://github.com/a-mcf/RetroSync/pull/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPDabb1qWZzkWzRfv7KCfm
