### PR TITLE
chore(renovate): track python base image by digest only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,212 +1,132 @@
 {
   enabled: true,
-  semanticCommits: 'enabled',
+  semanticCommits: "enabled",
   dependencyDashboard: true,
-  dependencyDashboardTitle: 'Renovate Dashboard',
-  suppressNotifications: [
-    'prIgnoreNotification',
-  ],
-  rebaseWhen: 'conflicted',
+  dependencyDashboardTitle: "Renovate Dashboard",
+  suppressNotifications: ["prIgnoreNotification"],
+  rebaseWhen: "conflicted",
   ignoreDeps: [
-    'ghcr.io/fluxcd/helm-controller',
-    'ghcr.io/fluxcd/image-automation-controller',
-    'ghcr.io/fluxcd/image-reflector-controller',
-    'ghcr.io/fluxcd/kustomize-controller',
-    'ghcr.io/fluxcd/notification-controller',
-    'ghcr.io/fluxcd/source-controller',
+    "ghcr.io/fluxcd/helm-controller",
+    "ghcr.io/fluxcd/image-automation-controller",
+    "ghcr.io/fluxcd/image-reflector-controller",
+    "ghcr.io/fluxcd/kustomize-controller",
+    "ghcr.io/fluxcd/notification-controller",
+    "ghcr.io/fluxcd/source-controller",
   ],
-  'pre-commit': {
+  "pre-commit": {
     enabled: true,
   },
   flux: {
-    managerFilePatterns: [
-      '/cluster/.+\\.ya?ml$/',
-    ],
+    managerFilePatterns: ["/cluster/.+\\.ya?ml$/"],
   },
-  'helm-values': {
-    managerFilePatterns: [
-      '/cluster/.+\\.ya?ml$/',
-    ],
+  "helm-values": {
+    managerFilePatterns: ["/cluster/.+\\.ya?ml$/"],
   },
   kubernetes: {
     managerFilePatterns: [
-      '/cluster/.+\\.ya?ml$/',
-      '/provision/ansible/.+\\.ya?ml.j2$/',
+      "/cluster/.+\\.ya?ml$/",
+      "/provision/ansible/.+\\.ya?ml.j2$/",
     ],
   },
   customManagers: [
     {
-      customType: 'regex',
+      customType: "regex",
       managerFilePatterns: [
-        '/cluster/.+\\.ya?ml$/',
-        '/provision/ansible/.+\\.ya?ml$/',
+        "/cluster/.+\\.ya?ml$/",
+        "/provision/ansible/.+\\.ya?ml$/",
       ],
       matchStrings: [
-        'datasource=(?<datasource>.*?)( versioning=(?<versioning>.*?))?\n *url: https://github\\.com/(?<depName>.*?)\\.git\n *ref:\n *tag: (?<currentValue>.*)\n',
+        "datasource=(?<datasource>.*?)( versioning=(?<versioning>.*?))?\n *url: https://github\\.com/(?<depName>.*?)\\.git\n *ref:\n *tag: (?<currentValue>.*)\n",
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?_version: "(?<currentValue>.*)"\n',
         'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?_VERSION="(?<currentValue>.*)"\n',
       ],
-      datasourceTemplate: '{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}',
-      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
+      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },
     {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/cluster/crds/cert-manager/.+\\.ya?ml$/',
-      ],
+      customType: "regex",
+      managerFilePatterns: ["/cluster/crds/cert-manager/.+\\.ya?ml$/"],
       matchStrings: [
-        'registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n.*\\/(?<currentValue>.*?)\\/',
+        "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n.*\\/(?<currentValue>.*?)\\/",
       ],
-      datasourceTemplate: 'helm',
+      datasourceTemplate: "helm",
     },
     {
-      customType: 'regex',
-      managerFilePatterns: [
-        '/cluster/crds/traefik/.+\\.ya?ml$/',
-      ],
+      customType: "regex",
+      managerFilePatterns: ["/cluster/crds/traefik/.+\\.ya?ml$/"],
       matchStrings: [
-        'registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n *tag: v(?<currentValue>.*)\n',
+        "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n *tag: v(?<currentValue>.*)\n",
       ],
-      datasourceTemplate: 'helm',
+      datasourceTemplate: "helm",
     },
   ],
   packageRules: [
     {
-      matchDatasources: [
-        'helm',
-      ],
+      matchDatasources: ["helm"],
       separateMinorPatch: true,
       ignoreDeprecated: true,
     },
     {
-      matchDatasources: [
-        'docker',
-      ],
+      matchDatasources: ["docker"],
       enabled: true,
-      commitMessageTopic: 'container image {{depName}}',
-      commitMessageExtra: 'to {{#if isSingleVersion}}v{{{newVersion}}}{{else}}{{{newValue}}}{{/if}}',
-      matchUpdateTypes: [
-        'major',
-        'minor',
-        'patch',
-      ],
+      commitMessageTopic: "container image {{depName}}",
+      commitMessageExtra: "to {{#if isSingleVersion}}v{{{newVersion}}}{{else}}{{{newValue}}}{{/if}}",
+      matchUpdateTypes: ["major", "minor", "patch"],
     },
     {
-      matchDatasources: [
-        'docker',
-      ],
-      matchUpdateTypes: [
-        'major',
-      ],
-      labels: [
-        'renovate/image',
-        'dep/major',
-      ],
+      matchDatasources: ["docker"],
+      matchUpdateTypes: ["major"],
+      labels: ["renovate/image", "dep/major"],
     },
     {
-      matchDatasources: [
-        'docker',
-      ],
-      matchUpdateTypes: [
-        'minor',
-      ],
-      labels: [
-        'renovate/image',
-        'dep/minor',
-      ],
+      matchDatasources: ["docker"],
+      matchUpdateTypes: ["minor"],
+      labels: ["renovate/image", "dep/minor"],
     },
     {
-      matchDatasources: [
-        'docker',
-      ],
-      matchUpdateTypes: [
-        'patch',
-      ],
-      labels: [
-        'renovate/image',
-        'dep/patch',
-      ],
+      matchDatasources: ["docker"],
+      matchUpdateTypes: ["patch"],
+      labels: ["renovate/image", "dep/patch"],
     },
     {
-      matchDatasources: [
-        'helm',
-      ],
-      matchUpdateTypes: [
-        'major',
-      ],
-      labels: [
-        'renovate/helm',
-        'dep/major',
-      ],
+      matchDatasources: ["helm"],
+      matchUpdateTypes: ["major"],
+      labels: ["renovate/helm", "dep/major"],
     },
     {
-      matchDatasources: [
-        'helm',
-      ],
-      matchUpdateTypes: [
-        'minor',
-      ],
-      labels: [
-        'renovate/helm',
-        'dep/minor',
-      ],
+      matchDatasources: ["helm"],
+      matchUpdateTypes: ["minor"],
+      labels: ["renovate/helm", "dep/minor"],
     },
     {
-      matchDatasources: [
-        'helm',
-      ],
-      matchUpdateTypes: [
-        'patch',
-      ],
-      labels: [
-        'renovate/helm',
-        'dep/patch',
-      ],
+      matchDatasources: ["helm"],
+      matchUpdateTypes: ["patch"],
+      labels: ["renovate/helm", "dep/patch"],
     },
     {
-      description: 'SearXNG datever tags (YYYY.M.D-shorthash) — without this rule renovate cannot order them and the image silently goes stale (11 months, July 2026)',
-      matchDatasources: [
-        'docker',
-      ],
-      matchPackageNames: [
-        'ghcr.io/searxng/searxng',
-      ],
-      versioning: 'regex:^(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>[a-f0-9]+)$',
+      description: "SearXNG datever tags (YYYY.M.D-shorthash) — without this rule renovate cannot order them and the image silently goes stale (11 months, July 2026)",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/searxng/searxng"],
+      versioning: "regex:^(?<major>\\d{4})\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>[a-f0-9]+)$",
     },
     {
-      description: 'Vane slim-prefixed tags (slim-vX.Y.Z) — prefix hides them from default versioning',
-      matchDatasources: [
-        'docker',
-      ],
-      matchPackageNames: [
-        'itzcrazykns1337/vane',
-      ],
-      versioning: 'regex:^slim-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+      description: "Vane slim-prefixed tags (slim-vX.Y.Z) — prefix hides them from default versioning",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["itzcrazykns1337/vane"],
+      versioning: "regex:^slim-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
     },
     {
-      description: 'python base image: security rebuilds (digest) only, never feature releases. The tools on this image keep their code in configMaps and pip-install deps at pod start, so a feature bump can only be validated by hand (ABI tag moves cp3XX, wheels must be rebuilt upstream; stdlib removals hit the scripts). Revisit if these move to built images with CI.',
-      matchDatasources: [
-        'docker',
-      ],
-      matchPackageNames: [
-        'python',
-      ],
-      matchUpdateTypes: [
-        'major',
-        'minor',
-      ],
+      description: "python base image: security rebuilds (digest) only, never feature releases. The tools on this image keep their code in configMaps and pip-install deps at pod start, so a feature bump can only be validated by hand (ABI tag moves cp3XX, wheels must be rebuilt upstream; stdlib removals hit the scripts). Revisit if these move to built images with CI.",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["python"],
+      matchUpdateTypes: ["major", "minor"],
       enabled: false,
     },
     {
-      description: 'Use loose versioning for certain dependencies',
-      matchDatasources: [
-        'docker',
-        'github-releases',
-      ],
-      versioning: 'loose',
-      matchPackageNames: [
-        '/plex/',
-      ],
+      description: "Use loose versioning for certain dependencies",
+      matchDatasources: ["docker", "github-releases"],
+      versioning: "loose",
+      matchPackageNames: ["/plex/"],
     },
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,43 +23,8 @@
     managerFilePatterns: ["/cluster/.+\\.ya?ml$/"],
   },
   kubernetes: {
-    managerFilePatterns: [
-      "/cluster/.+\\.ya?ml$/",
-      "/provision/ansible/.+\\.ya?ml.j2$/",
-    ],
+    managerFilePatterns: ["/cluster/.+\\.ya?ml$/"],
   },
-  customManagers: [
-    {
-      customType: "regex",
-      managerFilePatterns: [
-        "/cluster/.+\\.ya?ml$/",
-        "/provision/ansible/.+\\.ya?ml$/",
-      ],
-      matchStrings: [
-        "datasource=(?<datasource>.*?)( versioning=(?<versioning>.*?))?\n *url: https://github\\.com/(?<depName>.*?)\\.git\n *ref:\n *tag: (?<currentValue>.*)\n",
-        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?_version: "(?<currentValue>.*)"\n',
-        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?_VERSION="(?<currentValue>.*)"\n',
-      ],
-      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
-      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
-    },
-    {
-      customType: "regex",
-      managerFilePatterns: ["/cluster/crds/cert-manager/.+\\.ya?ml$/"],
-      matchStrings: [
-        "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n.*\\/(?<currentValue>.*?)\\/",
-      ],
-      datasourceTemplate: "helm",
-    },
-    {
-      customType: "regex",
-      managerFilePatterns: ["/cluster/crds/traefik/.+\\.ya?ml$/"],
-      matchStrings: [
-        "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n *tag: v(?<currentValue>.*)\n",
-      ],
-      datasourceTemplate: "helm",
-    },
-  ],
   packageRules: [
     {
       matchDatasources: ["helm"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,8 +23,43 @@
     managerFilePatterns: ["/cluster/.+\\.ya?ml$/"],
   },
   kubernetes: {
-    managerFilePatterns: ["/cluster/.+\\.ya?ml$/"],
+    managerFilePatterns: [
+      "/cluster/.+\\.ya?ml$/",
+      "/provision/ansible/.+\\.ya?ml.j2$/",
+    ],
   },
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: [
+        "/cluster/.+\\.ya?ml$/",
+        "/provision/ansible/.+\\.ya?ml$/",
+      ],
+      matchStrings: [
+        "datasource=(?<datasource>.*?)( versioning=(?<versioning>.*?))?\n *url: https://github\\.com/(?<depName>.*?)\\.git\n *ref:\n *tag: (?<currentValue>.*)\n",
+        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?_version: "(?<currentValue>.*)"\n',
+        'datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?_VERSION="(?<currentValue>.*)"\n',
+      ],
+      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/cluster/crds/cert-manager/.+\\.ya?ml$/"],
+      matchStrings: [
+        "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n.*\\/(?<currentValue>.*?)\\/",
+      ],
+      datasourceTemplate: "helm",
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: ["/cluster/crds/traefik/.+\\.ya?ml$/"],
+      matchStrings: [
+        "registryUrl=(?<registryUrl>.*?) chart=(?<depName>.*?)\n *tag: v(?<currentValue>.*)\n",
+      ],
+      datasourceTemplate: "helm",
+    },
+  ],
   packageRules: [
     {
       matchDatasources: ["helm"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -184,6 +184,20 @@
       versioning: 'regex:^slim-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
     {
+      description: 'python base image: security rebuilds (digest) only, never feature releases. The tools on this image keep their code in configMaps and pip-install deps at pod start, so a feature bump can only be validated by hand (ABI tag moves cp3XX, wheels must be rebuilt upstream; stdlib removals hit the scripts). Revisit if these move to built images with CI.',
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'python',
+      ],
+      matchUpdateTypes: [
+        'major',
+        'minor',
+      ],
+      enabled: false,
+    },
+    {
       description: 'Use loose versioning for certain dependencies',
       matchDatasources: [
         'docker',


### PR DESCRIPTION
The tools on the `python` base image keep their source in configMaps and pip-install dependencies at pod start. That means a Python **feature** release can't be validated by CI — only by hand: confirming upstream has published wheels for the new ABI tag (`cp3XX`), and that the scripts survive stdlib removals.

This disables `major`/`minor` for the `python` image so only **digest** rebuilds flow through — the security rebuilds, which can't change interpreter behaviour.

Revisit if these tools move to built images with their own CI, at which point feature releases become a build-time question with a CI answer.

Closes the need for #1635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhBENiX2QWeT4RpJZeHA8h