### PR TITLE
ci: validate renovate config against current renovate, not v39

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -46,3 +46,20 @@ jobs:
           # standardjs and js-prettier demand OPPOSITE quote/semicolon styles;
           # prettier is the repo-wide formatter, so it rules JS too
           VALIDATE_JAVASCRIPT_STANDARD: false
+          # super-linter bundles Renovate 39.x, which predates `fileMatch` being
+          # renamed to `managerFilePatterns`, so it rejects the current key on
+          # every manager — including flux/helm-values/kubernetes, which the
+          # dependency dashboard shows detecting 255 deps. Config is fine; the
+          # bundled validator is old. Replaced by the step below.
+          VALIDATE_RENOVATE: false
+
+      - name: Validate renovate config
+        # `@latest` is load-bearing, not laziness: the hosted Mend bot is always
+        # current, so validating against anything older reports failures the real
+        # bot would never produce. Bare `--package renovate` is NOT enough — npx
+        # will happily serve a cached older major (that is exactly how 39.x got
+        # mistaken for current while diagnosing this). If a future Renovate really
+        # does break this config, failing here is the signal we want.
+        run: npx --yes --package renovate@latest renovate-config-validator --strict
+        env:
+          RENOVATE_CONFIG_FILE: .github/renovate.json5


### PR DESCRIPTION
## What

super-linter bundles Renovate **39.x**, which predates `fileMatch` being renamed to `managerFilePatterns`. It therefore rejects the current key on **every** manager — including the three that demonstrably work: the dependency dashboard credits `flux` (57), `helm-values` (41) and `kubernetes` (157) with 255 detected dependencies between them.

The config is valid. Proof:

- `renovate-config-validator` from **44.29.3** → `Config validated successfully`
- the published schema contains `managerFilePatterns` **234** times and `fileMatch` **0** times

So this disables super-linter's stale check and validates in a dedicated step against `renovate@latest`.

## Why `@latest` rather than a pin

The hosted Mend bot is always current, so validating against anything older reports failures the real bot would never produce — which is precisely the bug being fixed. A pinned validator would drift back into the same state.

Note `--package renovate` alone is **not** sufficient: npx will serve a cached older major. That is exactly how 39.264.1 got mistaken for current while diagnosing this, on a machine where the registry's latest was 44.29.3.

## Why now

super-linter only lints changed files, and nothing had touched `renovate.json5` since July — so this had been dormant, waiting for the next PR to touch that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhBENiX2QWeT4RpJZeHA8h