### PR TITLE
fix(syncthing): move config + SQLite index off NFS to block storage

### DIFF
--- a/cluster/apps/syncthing/syncthing/app/config-pvc.yaml
+++ b/cluster/apps/syncthing/syncthing/app/config-pvc.yaml
@@ -1,4 +1,31 @@
 ---
+# Syncthing v2 keeps its indexes in SQLite (config/index-v2/*.db + -wal), and
+# SQLite on NFS is pathological: unreliable locking and largely defeated page
+# caching mean it re-reads constantly. Before this moved to block storage,
+# syncthing pegged a full CPU core continuously for days and racked up 73TB of
+# reads, tripping NodeMemoryMajorPagesFaults on its node. Under v1's LevelDB the
+# NFS layout was fine; the v2 migration (2026-08-06) is what broke it.
+#
+# This is the "CSI PV with a stated reason" carve-out from the storage philosophy.
+# Only config + database live here (~300MB); every synced folder stays on the NFS
+# /backups share, which is bulk file data and belongs there.
+#
+# ⚠ Backup coverage: the databases are regenerable (syncthing rebuilds indexes),
+# but config.xml and cert.pem/key.pem are NOT — they are this node's device
+# identity. Losing them means re-pairing every device.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: syncthing-config
+  namespace: syncthing
+spec:
+  storageClassName: proxmox-csi-ext4-ssd
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/cluster/apps/syncthing/syncthing/app/helm-release.yaml
+++ b/cluster/apps/syncthing/syncthing/app/helm-release.yaml
@@ -94,7 +94,10 @@ spec:
     persistence:
       data:
         enabled: true
-        existingClaim: nfs-syncthing-pvc
+        # Block storage, not NFS: v2 keeps its indexes in SQLite and SQLite on
+        # NFS thrashes (see config-pvc.yaml). Only config + db live here; the
+        # synced folders are all under /backups below.
+        existingClaim: syncthing-config
         globalMounts:
           - path: /var/syncthing
       backups:


### PR DESCRIPTION
## Problem

Syncthing v2 replaced LevelDB with SQLite. Its per-folder databases (`config/index-v2/*.db` + `-wal`) were on the NFS data volume, and SQLite over NFS thrashes — unreliable locking, page caching largely defeated, constant re-reads.

Measured on `k3s-node3`:

| | |
|---|---|
| CPU | **99.5% of a core, continuously** — 4d20h29m CPU in 4d21h elapsed |
| `read_bytes` | **73 TB** — ~70× the next busiest process on the node |
| major faults | **1,555/sec** vs the 500 alert threshold |

This tripped `NodeMemoryMajorPagesFaults`. Worth noting the alert name misleads: the node has **no swap at all** and sits at ~42% memory used. The faults are file-backed, not memory pressure.

Nothing showed in syncthing's logs — it reported normal syncs throughout. Under v1's LevelDB the NFS layout was fine; `index-v2` was created 2026-08-06, which is when the v2 migration broke it.

## Change

Moves **only config + database (~300MB)** to `proxmox-csi-ext4-ssd` — the same storage class the authentik Postgres uses. Every synced folder stays on the NFS `/backups` share; those are bulk files and belong there.

This is the "CSI PV with a stated reason" carve-out from the storage philosophy.

## Migration

Data was copied before this merges: Flux suspended, deployment scaled to 0, `cp -a` via a temporary pod running as uid 2316 (the NFS export uses root_squash, so root reads are denied). Verified 12 db files, all 3 identity files, ownership `2316:2316`, matching byte counts. `config.xml` and both keypairs were backed up separately — those are the device identity and are *not* regenerable.

## Rollback

The old NFS PV/PVC are left defined with `Retain`, so the previous data is intact. Revert by repointing `existingClaim` back to `nfs-syncthing-pvc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)