### PR TITLE
feat(litellm): add agent tier aliases with fallback to local

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -37,6 +37,55 @@ data:
           model: openai/google/gemma-4-12B-it-qat-w4a16-ct
           api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
           api_key: sk-noauth
+      # --- agent tier -----------------------------------------------------
+      # A separate accelerator with enough memory to keep several models
+      # resident at once, so switching between them costs nothing. Kept
+      # separate from "local" on purpose -- the agent hardware trades latency
+      # for capability, which is the opposite of what the voice path wants.
+      # Moving this tier to different hardware is a cluster-secrets var change,
+      # not a config change; consumers keep pointing at "agent".
+      #
+      # Routing rule, measured rather than assumed: generation here is
+      # memory-bandwidth-bound, so tok/s tracks model size, not cleverness.
+      # Anything that fits on the 3090 belongs on the 3090 -- these aliases
+      # earn their keep on tool-calling and long-context work, not on speed.
+      - model_name: agent
+        litellm_params:
+          # Mixture-of-experts, ~3B active params: generation tracks ACTIVE
+          # weights, so this answers faster than models a quarter its size.
+          # Best measured tool discipline + latency combination available here.
+          #
+          # CALLER BEWARE, both of these bit us during evaluation:
+          #  - it reasons at length with NO delimiter token, so a small
+          #    max_tokens truncates mid-thought and is indistinguishable from a
+          #    refusal or an empty tool call. Budget >=3000.
+          #  - no reasoning parser is configured upstream, so that reasoning
+          #    arrives inline in `content` alongside any tool_calls. Read
+          #    tool_calls structurally; don't parse the prose.
+          model: openai/nemotron35-lightning
+          api_base: http://${VLLM_DELL_HOST}:8000/v1
+          api_key: sk-noauth
+      - model_name: agent-precise
+        litellm_params:
+          # Slower (~5x) but follows fiddly instructions more literally --
+          # e.g. rewriting a vague request into a concrete search term where
+          # "agent" leaves it generic. Worth it when the argument matters more
+          # than the round-trip.
+          model: openai/qwen38-27b
+          api_base: http://${VLLM_DELL_HOST}:8001/v1
+          api_key: sk-noauth
+      # Explicit pins, same backends -- for A/B work where you need to name the
+      # model rather than the job. Mirrors the local/gemma4-12b pairing above.
+      - model_name: nemotron35-lightning
+        litellm_params:
+          model: openai/nemotron35-lightning
+          api_base: http://${VLLM_DELL_HOST}:8000/v1
+          api_key: sk-noauth
+      - model_name: qwen38-27b
+        litellm_params:
+          model: openai/qwen38-27b
+          api_base: http://${VLLM_DELL_HOST}:8001/v1
+          api_key: sk-noauth
       # --- future backends: add paid/free providers here, gated by sensitivity
       # tier. e.g. a cloud frontier model for hard/non-sensitive work:
       # - model_name: cloud-hard
@@ -47,7 +96,16 @@ data:
     litellm_settings:
       drop_params: true          # tolerate params a backend doesn't support
       # num_retries: 2
-      # fallbacks: [{"local": ["cloud-hard"]}]   # when local is down/gaming
+
+    router_settings:
+      # Degrade rather than fail: the agent tier runs on hardware that is not
+      # ours to keep, so every alias pointing at it has a way home. "local" is
+      # a much smaller model -- this is a floor, not an equivalent.
+      # NOTE: fallbacks belong under router_settings (validated against the
+      # Router signature); the older litellm_settings spelling is legacy.
+      fallbacks:
+        - agent: ["agent-precise", "local"]
+        - agent-precise: ["agent", "local"]
 
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY

--- a/cluster/base/cluster-secrets.yaml
+++ b/cluster/base/cluster-secrets.yaml
@@ -42,14 +42,15 @@ stringData:
     INGRESS_NGINX_INTERNAL_LB: ENC[AES256_GCM,data:qKaaTwLHIjnKOlZm,iv:zirZnzUIMztfSzt2SCCnuu3Lrulou2EgeQVjyQ31vhs=,tag:90Um5oXMMyYXDn2a4K0J0w==,type:str]
     TRAEFIK_LB: ENC[AES256_GCM,data:+5y15wHd+6Cs1qkE,iv:9+dsrIe0t7bXLVq/IHYuXFk90DSOhvcQvMil85MMf38=,tag:jH2rwqXFYQOXyW7+RBMIag==,type:str]
     SECRET_ALERTMANAGER_DEADMAN_URL: ENC[AES256_GCM,data:9wo6IJFkTA0/xgJmrDFODvgHX9zPlD+R6EKTTH6RAor5KNhtjGSPneVOxwFp61IlXY3hYIkQX00=,iv:dOrp0v90mYIgDcjbXmLFCPjX6/wX0WyPjQohtlEkgPY=,tag:IRBr5JZYHqyOUxNxG0xL7Q==,type:str]
+    VLLM_DELL_HOST: ENC[AES256_GCM,data:BqY3neFZVZktJjE=,iv:OOo2sH2UQof/FhEZpRS4eg6UOGONE8chWlkcw1Zvks0=,tag:m7Cy3O+dUgg68IVvOXjV6w==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2026-07-04T17:21:53Z"
-    mac: ENC[AES256_GCM,data:ot7BWVewjfZC6O41Ad0bLND6JoiibfHJoz1N5kutup1KPblpPmeBvjNU5UwB5zGnCdCImf9roFThsOFfDCtDbPF2h1r66C6c3zad1sAmWwNKnwqkIj+u2vAzs+9ydBFmDsZNgPUGrUIfEEN8fUpsidPbBVJs1v3bPV6jMd3Edz0=,iv:P6572Ewxvw92rU58GZgTE9rNbgtYa0CFsm0I8VIDzG4=,tag:vFoJY+TtooEW3bifEEnMkQ==,type:str]
+    lastmodified: "2026-08-20T22:44:11Z"
+    mac: ENC[AES256_GCM,data:nM9JdpS5Ax6CoLdpoSE2Y9aIwpntilOgFFc+NTRWeQx0OyD/8sMu1QyXPZ3prfx/7N5fiX3m6ye68/eztSe4pdWlC73lDVdmiVB7LaJjF8+ihwd6iZXcFoNqYt+dZdUWsLhGoSZqR/gFIL+qTJyiLkRrlJO47vdqr7GJAMrtN2w=,iv:EaFzBLFbY+W6ApVARfWoiCu4p2yvpy5bE3Gkk4umkIQ=,tag:E8EMsMJ76gpmauMRNYfCxw==,type:str]
     pgp:
         - created_at: "2021-04-27T01:36:09Z"
           enc: |


### PR DESCRIPTION
Wires the second inference host into the LiteLLM gateway as its own routing tier.

## Aliases

| alias | backend | job |
|---|---|---|
| `local` | gemma4-12B | unchanged — voice/GLaDOS, latency-critical |
| `agent` | `nemotron35-lightning` | tool-calling workhorse; MoE with ~3B active params, so it answers faster than models a quarter its size |
| `agent-precise` | `qwen38-27b` | ~5x slower but follows fiddly instructions more literally |
| `nemotron35-lightning`, `qwen38-27b` | same backends | explicit pins for A/B work |

Role aliases + explicit pins mirrors the existing `local` / `gemma4-12b` pairing: consumers point at the job, and swapping the model or the host underneath is a one-line change here instead of a re-plumb downstream.

## Fallbacks

Declared under `router_settings` — verified against the installed LiteLLM that these keys are validated against the `Router` signature, and that `fallbacks` is one of them. The `litellm_settings` spelling that was previously commented out is the legacy location.

Both agent aliases fall back to each other, then to `local`, so the tier degrades rather than fails if its backend goes away. `local` is a much smaller model — a floor, not an equivalent.

## Notes

- Backend address comes from a new SOPS var rather than a literal. Re-encrypted in editor mode so unchanged values keep their existing ciphertext — the diff is the one new key plus `mac`/`lastmodified`.
- **No NetworkPolicy changes needed.** The netpol baseline is ingress-only default-deny; there are no egress policies anywhere in the cluster. Verified empirically by reaching both backends from inside the running litellm pod.
- Documented two caller-facing gotchas found during evaluation: the agent model reasons at length with no delimiter token (a small `max_tokens` truncates mid-thought and looks like a refusal), and no reasoning parser is configured upstream, so reasoning arrives inline in `content` alongside `tool_calls`.

## Verification

- Both backends live and healthy; tool calls round-trip with correct arguments on each.
- `kustomize build` clean, kubeconform clean, yamllint/prettier clean, sops-guard clean.
- Post-merge: confirm `/v1/models` lists the new aliases and a completion + tool call round-trips through `agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN5yBQkJWqT1xtfCtvh3kp