### PR TITLE
chore(litellm): drop the dead gemma4-26b alias

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -25,11 +25,10 @@ data:
           api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
           api_key: sk-noauth
       # Explicit names so you can pin a specific backend regardless of what "local" is.
-      - model_name: gemma4-26b
-        litellm_params:
-          model: openai/gemma4-26b
-          api_base: http://llamacpp.ai.svc.cluster.local:8080/v1
-          api_key: sk-noauth
+      # NOTE: no gemma4-26b alias. The llamacpp backend behind it is parked at 0
+      # replicas, so the alias only ever returned a 500 -- and every consumer that
+      # lists models (OpenWebUI et al) still showed it as a choice. Re-add it here
+      # if llamacpp is ever brought back up.
       - model_name: gemma4-12b
         litellm_params:
           # vLLM 12B — parked (its replicaCount is 0 while the 26B holds the GPU);


### PR DESCRIPTION
The `gemma4-26b` alias pointed at the llamacpp backend, which has been parked at **0 replicas since June** — so the alias only ever returned a 500, while still appearing as a selectable model in every consumer that lists `/v1/models` (OpenWebUI, etc).

Verified before removal:

```
gemma4-26b   FAIL 500   litellm.InternalServerError: OpenAIException ...
```

Remaining aliases, all confirmed serving:

| alias | latency |
|---|---|
| `local` / `gemma4-12b` | 0.1s |
| `agent` / `nemotron35-lightning` | 0.3s |
| `agent-precise` / `qwen38-27b` | 1.4s |

Checked that no fallback chain references the removed name, so nothing is left dangling.

**Leaves the parked llamacpp app itself alone** — that's a separate decision. This only stops the gateway advertising a backend that can't answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN5yBQkJWqT1xtfCtvh3kp