### PR TITLE
fix(litellm): fail over-length requests instead of silently downgrading

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -97,11 +97,9 @@ data:
       # num_retries: 2
 
     router_settings:
-      # Degrade rather than fail: the agent tier runs on hardware that is not
-      # ours to keep, so every alias pointing at it has a way home. "local" is
-      # a much smaller model -- this is a floor, not an equivalent.
-      # NOTE: fallbacks belong under router_settings (validated against the
-      # Router signature); the older litellm_settings spelling is legacy.
+      # "local" is a much smaller model: a floor, not an equivalent.
+      # `fallbacks` belongs under router_settings; the litellm_settings
+      # spelling is legacy and is silently ignored.
       fallbacks:
         - agent: ["agent-precise", "local"]
         - agent-precise: ["agent", "local"]

--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -106,5 +106,30 @@ data:
         - agent: ["agent-precise", "local"]
         - agent-precise: ["agent", "local"]
 
+      # An over-length request must FAIL, not silently downgrade.
+      #
+      # Without this, a prompt longer than the agent tier's window raises
+      # ContextWindowExceededError, walks the chain above, and is answered by
+      # the much smaller "local" model -- HTTP 200, no warning, and no caller
+      # surfaces the `model` field to notice. That is substitution rather than
+      # truncation, and it is worse: the session looks fine and quietly gets
+      # answers from a model a fraction of the size.
+      #
+      # Mechanism, read from the running router rather than the docs: on a
+      # context-window error, if this setting is not None and has no entry for
+      # the requested group, the original exception is re-raised. If it IS
+      # None, control falls through to the generic fallbacks above.
+      #
+      # Two traps, both load-bearing:
+      #  - the sentinel must be NON-EMPTY. An empty list is falsy and collapses
+      #    straight back to None (`context_window_fallbacks or
+      #    litellm.context_window_fallbacks`), restoring the old behaviour.
+      #  - it must not name any real alias, or that alias gets a context
+      #    fallback instead of an error.
+      # Only the structure is validated (exactly one key per dict), never the
+      # names -- so an alias that cannot exist is the way to say "never".
+      context_window_fallbacks:
+        - __no_context_window_fallback__: ["__none__"]
+
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY

--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -106,28 +106,10 @@ data:
         - agent: ["agent-precise", "local"]
         - agent-precise: ["agent", "local"]
 
-      # An over-length request must FAIL, not silently downgrade.
-      #
-      # Without this, a prompt longer than the agent tier's window raises
-      # ContextWindowExceededError, walks the chain above, and is answered by
-      # the much smaller "local" model -- HTTP 200, no warning, and no caller
-      # surfaces the `model` field to notice. That is substitution rather than
-      # truncation, and it is worse: the session looks fine and quietly gets
-      # answers from a model a fraction of the size.
-      #
-      # Mechanism, read from the running router rather than the docs: on a
-      # context-window error, if this setting is not None and has no entry for
-      # the requested group, the original exception is re-raised. If it IS
-      # None, control falls through to the generic fallbacks above.
-      #
-      # Two traps, both load-bearing:
-      #  - the sentinel must be NON-EMPTY. An empty list is falsy and collapses
-      #    straight back to None (`context_window_fallbacks or
-      #    litellm.context_window_fallbacks`), restoring the old behaviour.
-      #  - it must not name any real alias, or that alias gets a context
-      #    fallback instead of an error.
-      # Only the structure is validated (exactly one key per dict), never the
-      # names -- so an alias that cannot exist is the way to say "never".
+      # Context-window errors re-raise instead of walking `fallbacks` above.
+      # Must be non-empty and must not name a real alias: `[] or
+      # litellm.context_window_fallbacks` makes an empty list collapse to None,
+      # which restores the fallback behaviour. Names are never validated.
       context_window_fallbacks:
         - __no_context_window_fallback__: ["__none__"]
 


### PR DESCRIPTION
An over-length request was returning `200 OK` answered by a different, much smaller model.

`ContextWindowExceededError` was falling through to the generic `fallbacks` chain, so a prompt past the agent tier's window walked `agent -> agent-precise -> local` and got answered by the smallest backend, with nothing in the response that any caller surfaces. Substitution rather than truncation, and invisible in normal use.

Reproduced against the running proxy: a 40k-token request to `agent` returned `200` with `model: google/gemma-4-12B-it-qat-w4a16-ct`.

## Fix

Set `context_window_fallbacks` to a sentinel naming no real alias. Read from the running router rather than the docs: on a context-window error, if the setting is non-None and has no entry for the requested group, the original exception is re-raised; if it is None, control falls through to the generic fallbacks.

Two traps, documented inline because each silently undoes the fix:

- the sentinel must be **non-empty** — an empty list is falsy and collapses back to `None` via `context_window_fallbacks or litellm.context_window_fallbacks`
- it must **not name a real alias**, or that alias gets a context fallback rather than an error

Only the structure is validated (exactly one key per dict), never the names.

Generic fallbacks are unchanged, so availability failover still degrades as designed. Only context overflow now fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW