### PR TITLE
feat(litellm): back the proxy with CNPG for virtual keys, spend and the UI

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -1,8 +1,9 @@
 ---
-# LiteLLM proxy config — config-file-only mode (no DB).
-# Upgrade path to DB-backed (virtual keys, spend tracking, admin UI): stand up a
-# CloudNative-PG Cluster for litellm, add DATABASE_URL (from its secret) +
-# STORE_MODEL_IN_DB=true to the helm-release env, then keys/spend live in PG.
+# LiteLLM proxy config. Models are defined HERE and only here.
+# A CloudNative-PG cluster backs the proxy (see ../database) for virtual keys,
+# spend tracking and the admin UI -- but STORE_MODEL_IN_DB is deliberately left
+# off, so model_list below stays the single reviewable source of truth rather
+# than drifting into rows that only exist in Postgres.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -1,9 +1,6 @@
 ---
-# LiteLLM proxy config. Models are defined HERE and only here.
-# A CloudNative-PG cluster backs the proxy (see ../database) for virtual keys,
-# spend tracking and the admin UI -- but STORE_MODEL_IN_DB is deliberately left
-# off, so model_list below stays the single reviewable source of truth rather
-# than drifting into rows that only exist in Postgres.
+# LiteLLM proxy config. Postgres backs keys/spend/UI (see ../database).
+# STORE_MODEL_IN_DB is off, so model_list here is authoritative.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/apps/ai/litellm/app/helm-release.yaml
+++ b/cluster/apps/ai/litellm/app/helm-release.yaml
@@ -32,6 +32,22 @@ spec:
               - "/etc/litellm/config.yaml"
               - "--port"
               - "4000"
+            env:
+              # Lights up virtual keys, per-key spend tracking, and the admin UI
+              # (which returns "Not connected to DB!" on login without this).
+              # CNPG publishes a ready-made connection string in <cluster>-app,
+              # so there is nothing to assemble or keep in sync by hand.
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm-cnpg-app
+                    key: uri
+              # STORE_MODEL_IN_DB is deliberately NOT set. It would let models be
+              # added through the UI, and those live only in Postgres -- invisible
+              # to git and silently divergent from the configmap. model_list stays
+              # the single source of truth; the database is here for keys, spend
+              # and the UI. Flip it on only if UI-managed models are ever wanted
+              # more than a reviewable history of what this gateway serves.
             envFrom:
               - secretRef:
                   name: litellm-secret
@@ -39,6 +55,20 @@ spec:
               # TCP probes for the MVP — robust against a path typo on first boot.
               # Upgrade to HTTP later: liveness /health/liveliness,
               # readiness /health/readiness (LiteLLM's own endpoints).
+              #
+              # With DATABASE_URL set, the first boot against an empty database
+              # runs Prisma migrations before the port is bound. Liveness alone
+              # would kill that at ~110s and crash-loop it; a startup probe holds
+              # liveness and readiness off until the port answers.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 4000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 60
               liveness:
                 enabled: true
                 custom: true

--- a/cluster/apps/ai/litellm/app/helm-release.yaml
+++ b/cluster/apps/ai/litellm/app/helm-release.yaml
@@ -33,21 +33,14 @@ spec:
               - "--port"
               - "4000"
             env:
-              # Lights up virtual keys, per-key spend tracking, and the admin UI
-              # (which returns "Not connected to DB!" on login without this).
-              # CNPG publishes a ready-made connection string in <cluster>-app,
-              # so there is nothing to assemble or keep in sync by hand.
+              # CNPG publishes a ready-made connection string in <cluster>-app.
               DATABASE_URL:
                 valueFrom:
                   secretKeyRef:
                     name: litellm-cnpg-app
                     key: uri
-              # STORE_MODEL_IN_DB is deliberately NOT set. It would let models be
-              # added through the UI, and those live only in Postgres -- invisible
-              # to git and silently divergent from the configmap. model_list stays
-              # the single source of truth; the database is here for keys, spend
-              # and the UI. Flip it on only if UI-managed models are ever wanted
-              # more than a reviewable history of what this gateway serves.
+              # STORE_MODEL_IN_DB unset: when on, the DB deep-merges over
+              # router_settings/litellm_settings from this config, DB winning.
             envFrom:
               - secretRef:
                   name: litellm-secret
@@ -55,11 +48,8 @@ spec:
               # TCP probes for the MVP — robust against a path typo on first boot.
               # Upgrade to HTTP later: liveness /health/liveliness,
               # readiness /health/readiness (LiteLLM's own endpoints).
-              #
-              # With DATABASE_URL set, the first boot against an empty database
-              # runs Prisma migrations before the port is bound. Liveness alone
-              # would kill that at ~110s and crash-loop it; a startup probe holds
-              # liveness and readiness off until the port answers.
+              # First boot runs Prisma migrations before binding the port,
+              # which outlasts the liveness budget below.
               startup:
                 enabled: true
                 custom: true

--- a/cluster/apps/ai/litellm/database/cluster.yaml
+++ b/cluster/apps/ai/litellm/database/cluster.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/a-mcf/4adb544a0629376aefb4b259223e6bcc/raw/28fd33b190394e1777948ec7908f488133721e3d/gistfile1.txt
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: litellm-cnpg
+  namespace: ai
+spec:
+  enableSuperuserAccess: true
+  instances: 1
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.4
+  inheritedMetadata:
+    labels:
+      kube-image-keeper.enix.io/image-caching-policy: ignore
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 10Gi
+    storageClass: proxmox-csi-ext4-ssd
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 256MB
+  monitoring:
+    enablePodMonitor: true
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: litellm-objectstore
+        serverName: litellm-cnpg
+
+  # A NEW database, so initdb rather than the recovery bootstrap the older
+  # clusters here use (those were restored during the minio -> garage move).
+  bootstrap:
+    initdb:
+      database: litellm
+      owner: litellm

--- a/cluster/apps/ai/litellm/database/cluster.yaml
+++ b/cluster/apps/ai/litellm/database/cluster.yaml
@@ -31,8 +31,6 @@ spec:
         barmanObjectName: litellm-objectstore
         serverName: litellm-cnpg
 
-  # A NEW database, so initdb rather than the recovery bootstrap the older
-  # clusters here use (those were restored during the minio -> garage move).
   bootstrap:
     initdb:
       database: litellm

--- a/cluster/apps/ai/litellm/database/external-secret.yaml
+++ b/cluster/apps/ai/litellm/database/external-secret.yaml
@@ -1,0 +1,22 @@
+---
+# The barman-cloud ObjectStore reads its S3 credentials from a Secret in its OWN
+# namespace, so every namespace with a backed-up cluster needs this copy.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudnative-pg-secret-garage
+  namespace: ai
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password-connect
+  target:
+    name: cloudnative-pg-secret-garage
+    template:
+      engineVersion: v2
+      data:
+        garage-access-key-id: "{{ .GARAGE_S3_ACCESS_KEY }}"
+        garage-secret-access-key: "{{ .GARAGE_S3_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: cnpg-garage

--- a/cluster/apps/ai/litellm/database/external-secret.yaml
+++ b/cluster/apps/ai/litellm/database/external-secret.yaml
@@ -1,6 +1,5 @@
 ---
-# The barman-cloud ObjectStore reads its S3 credentials from a Secret in its OWN
-# namespace, so every namespace with a backed-up cluster needs this copy.
+# barman-cloud reads S3 credentials from a Secret in its own namespace.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/cluster/apps/ai/litellm/database/kustomization.yaml
+++ b/cluster/apps/ai/litellm/database/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+resources:
+  - ./external-secret.yaml
+  - ./objectstore.yaml
+  - ./cluster.yaml
+  - ./scheduledbackup.yaml

--- a/cluster/apps/ai/litellm/database/objectstore.yaml
+++ b/cluster/apps/ai/litellm/database/objectstore.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: litellm-objectstore
+  namespace: ai
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://cnpg-backups
+    endpointURL: https://s3-premium.${SECRET_DOMAIN}
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret-garage
+        key: garage-access-key-id
+      secretAccessKey:
+        name: cloudnative-pg-secret-garage
+        key: garage-secret-access-key
+    wal:
+      compression: bzip2
+      maxParallel: 8

--- a/cluster/apps/ai/litellm/database/scheduledbackup.yaml
+++ b/cluster/apps/ai/litellm/database/scheduledbackup.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: litellm-backup
+  namespace: ai
+spec:
+  # Staggered away from the other cluster backups (21:00 authentik,
+  # 21:30 retrosync, 22:00 freshrss + mealie, 23:40 immich).
+  schedule: "0 10 23 * *"
+  backupOwnerReference: self
+  cluster:
+    name: litellm-cnpg
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/cluster/apps/ai/litellm/database/scheduledbackup.yaml
+++ b/cluster/apps/ai/litellm/database/scheduledbackup.yaml
@@ -5,8 +5,6 @@ metadata:
   name: litellm-backup
   namespace: ai
 spec:
-  # Staggered away from the other cluster backups (21:00 authentik,
-  # 21:30 retrosync, 22:00 freshrss + mealie, 23:40 immich).
   schedule: "0 10 23 * *"
   backupOwnerReference: self
   cluster:

--- a/cluster/apps/ai/litellm/ks.yaml
+++ b/cluster/apps/ai/litellm/ks.yaml
@@ -2,12 +2,35 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: cluster-apps-litellm-database
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/ai/litellm/database
+  dependsOn:
+    - name: cluster-apps-external-secrets-store-onepassword
+    - name: cluster-apps-proxmox-csi
+    - name: cluster-apps-garage-premium
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: cluster-apps-litellm
   namespace: flux-system
 spec:
   path: "./cluster/apps/ai/litellm/app"
   dependsOn:
     - name: cluster-apps-external-secrets-store-onepassword
+    # The proxy crash-loops if DATABASE_URL points at a cluster that is not up
+    # yet, so the database Kustomization has to settle first.
+    - name: cluster-apps-litellm-database
   prune: true
   sourceRef:
     kind: GitRepository

--- a/cluster/apps/ai/litellm/ks.yaml
+++ b/cluster/apps/ai/litellm/ks.yaml
@@ -28,8 +28,6 @@ spec:
   path: "./cluster/apps/ai/litellm/app"
   dependsOn:
     - name: cluster-apps-external-secrets-store-onepassword
-    # The proxy crash-loops if DATABASE_URL points at a cluster that is not up
-    # yet, so the database Kustomization has to settle first.
     - name: cluster-apps-litellm-database
   prune: true
   sourceRef:

--- a/cluster/apps/ai/netpol/kustomization.yaml
+++ b/cluster/apps/ai/netpol/kustomization.yaml
@@ -7,5 +7,10 @@ components:
   - ../../../base/components/netpol/baseline
   - ../../../base/components/netpol/ingress-controller
   - ../../../base/components/netpol/hostnetwork-clients
+  # Required by the litellm CNPG cluster. allow-same-namespace already covers
+  # the proxy reaching Postgres, but the operator lives in its own namespace and
+  # has to reach the instance -- without this the Cluster never goes Ready, and
+  # it fails looking like a storage or bootstrap problem rather than a netpol.
+  - ../../../base/components/netpol/cnpg-operator
 resources:
   - ./extras.yaml

--- a/cluster/apps/ai/netpol/kustomization.yaml
+++ b/cluster/apps/ai/netpol/kustomization.yaml
@@ -7,10 +7,8 @@ components:
   - ../../../base/components/netpol/baseline
   - ../../../base/components/netpol/ingress-controller
   - ../../../base/components/netpol/hostnetwork-clients
-  # Required by the litellm CNPG cluster. allow-same-namespace already covers
-  # the proxy reaching Postgres, but the operator lives in its own namespace and
-  # has to reach the instance -- without this the Cluster never goes Ready, and
-  # it fails looking like a storage or bootstrap problem rather than a netpol.
+  # The operator reaches instances from its own namespace; without this a
+  # Cluster never goes Ready.
   - ../../../base/components/netpol/cnpg-operator
 resources:
   - ./extras.yaml


### PR DESCRIPTION
The admin UI has never worked — login returns `Not connected to DB!` — and every consumer currently shares the master key, so rotating one app's access means re-plumbing all of them. Both need a database. Neither needs a cloud provider first.

## What's here

- single-instance CNPG cluster in ns `ai`, `initdb` (new database, not the recovery bootstrap the older clusters use from the minio → garage move)
- barman-cloud `ObjectStore` + `ScheduledBackup` to garage, retention 30d, scheduled at 23:10 to stagger away from the existing cluster backups
- `cloudnative-pg-secret-garage` ExternalSecret, since barman reads S3 credentials from a Secret in its own namespace
- `DATABASE_URL` wired from the CNPG-published `litellm-cnpg-app` secret, so there is no connection string to assemble or keep in sync
- `ks.yaml` split so the app waits on the database

## Deliberately not included

`STORE_MODEL_IN_DB` stays off. It would allow models to be added through the UI, where they exist only in Postgres and diverge silently from the configmap. `model_list` remains the single reviewable source of truth; the database is here for keys, spend and the UI.

Per-key model-group scoping is also left out. With every backend on local hardware it protects nothing — worth revisiting when there is a cloud provider, as a reason rather than a prerequisite.

## Two things found while building this

Both would have failed in misleading ways:

- **ns `ai` lacked the `cnpg-operator` NetworkPolicy component** that every other database namespace has. `allow-same-namespace` covers the proxy reaching Postgres, but the operator reaches in from its own namespace — without it the Cluster never goes Ready, presenting as a storage or bootstrap fault.
- **First boot against an empty database runs Prisma migrations before the port binds**, which the existing liveness probe would kill at ~110s and crash-loop. Added a startup probe to hold liveness and readiness off until the port answers.

## After merge

Virtual keys per consumer (OpenWebUI, Vane, GLaDOS/HA, the calendar mirrors, opencode) as a follow-up, then the master key stops being the shared credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW