### PR TITLE
feat(litellm): enable STORE_MODEL_IN_DB

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -1,6 +1,6 @@
 ---
-# LiteLLM proxy config. Postgres backs keys/spend/UI (see ../database).
-# STORE_MODEL_IN_DB is off, so model_list here is authoritative.
+# LiteLLM proxy config. Postgres backs keys/spend/UI (see ../database) and
+# holds models added through the UI; model_list here loads either way.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/cluster/apps/ai/litellm/app/helm-release.yaml
+++ b/cluster/apps/ai/litellm/app/helm-release.yaml
@@ -39,8 +39,9 @@ spec:
                   secretKeyRef:
                     name: litellm-cnpg-app
                     key: uri
-              # STORE_MODEL_IN_DB unset: when on, the DB deep-merges over
-              # router_settings/litellm_settings from this config, DB winning.
+              # DB rows deep-merge over general_settings/router_settings/
+              # litellm_settings from the configmap, with the DB winning.
+              STORE_MODEL_IN_DB: "true"
             envFrom:
               - secretRef:
                   name: litellm-secret


### PR DESCRIPTION
Allows models to be added and managed through the admin UI.

Verified the env var is actually honoured in the running version — `get_secret_bool("STORE_MODEL_IN_DB", ...)` in `proxy_server.py` — so no duplicate `general_settings` entry is needed.

## Wider effect, worth knowing

This is not limited to models. With it on, `_update_config_from_db` also pulls `general_settings`, `router_settings`, `litellm_settings` and `environment_variables` from the database and deep-merges them **over** the configmap, with the database winning.

So a setting changed through the UI silently overrides this file — including the `context_window_fallbacks` guard added in #1702. Git would show the guard while the running proxy used the database value.

Nothing overrides today: the database is fresh and holds no config rows. This is a note about what the UI can now do, not a current divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW