### PR TITLE
feat(switchyard): scrape the router and ship a dashboard

### DIFF
--- a/cluster/apps/ai/kustomization.yaml
+++ b/cluster/apps/ai/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./vllm/ks.yaml
   - ./litellm/ks.yaml
   - ./llamacpp/ks.yaml
+  - ./switchyard/ks.yaml
   - ./netpol

--- a/cluster/apps/ai/switchyard/app/dashboards/switchyard.json
+++ b/cluster/apps/ai/switchyard/app/dashboards/switchyard.json
@@ -1,0 +1,175 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "title": "Switchyard router",
+  "uid": "switchyard-router",
+  "tags": ["ai", "switchyard"],
+  "timezone": "browser",
+  "time": { "from": "now-24h", "to": "now" },
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "bargauge",
+      "title": "Share of decisions by model",
+      "description": "Which backend actually served, over the dashboard time range. With the random route this should track the configured weights; drift means something else is selecting.",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (selected_model) (increase(switchyard_decisions_total{job=\"switchyard\"}[$__range]))",
+          "legendFormat": "{{selected_model}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "showUnfilled": true,
+        "valueMode": "text",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "fixed", "fixedColor": "text" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "nemotron35-lightning" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#4C8DF6" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "qwen38-27b" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#CC7A33" } }]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Responses by outcome",
+      "description": "Errors are the half of an A/B that a clean benchmark never shows.",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (outcome) (rate(switchyard_client_responses_total{job=\"switchyard\"}[5m]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "success" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "retryable_error" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "other_error" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Decision rate by model",
+      "description": "Routing decisions per second, split by the model selected.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (selected_model) (rate(switchyard_decisions_total{job=\"switchyard\"}[5m]))",
+          "legendFormat": "{{selected_model}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "nemotron35-lightning" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#4C8DF6" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "qwen38-27b" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#CC7A33" } }]
+          }
+        ]
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Completion tokens per second by model",
+      "description": "Work done, not requests served. A model can win on decisions and lose here.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (model) (rate(switchyard_completion_tokens_total{job=\"switchyard\"}[5m]))",
+          "legendFormat": "{{model}}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "nemotron35-lightning" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#4C8DF6" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "qwen38-27b" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#CC7A33" } }]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/cluster/apps/ai/switchyard/app/kustomization.yaml
+++ b/cluster/apps/ai/switchyard/app/kustomization.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./scrapeconfig.yaml
+configMapGenerator:
+  - name: grafana-dashboards-switchyard
+    namespace: monitoring
+    files:
+      - dashboards/switchyard.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+      disableNameSuffixHash: true

--- a/cluster/apps/ai/switchyard/app/scrapeconfig.yaml
+++ b/cluster/apps/ai/switchyard/app/scrapeconfig.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: switchyard
+  namespace: ai
+  labels:
+    # Required: the Prometheus CR's scrapeConfigSelector matches on this, and a
+    # ScrapeConfig without it is ignored with no error anywhere.
+    release: kube-prometheus-stack
+spec:
+  metricsPath: /metrics
+  scrapeInterval: 30s
+  staticConfigs:
+    - targets:
+        - "${VLLM_GX10_HOST}:4000"
+      labels:
+        job: switchyard

--- a/cluster/apps/ai/switchyard/ks.yaml
+++ b/cluster/apps/ai/switchyard/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-switchyard
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/ai/switchyard/app
+  dependsOn:
+    - name: cluster-apps-kube-prometheus-stack
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/cluster/base/cluster-secrets.yaml
+++ b/cluster/base/cluster-secrets.yaml
@@ -43,14 +43,15 @@ stringData:
     TRAEFIK_LB: ENC[AES256_GCM,data:+5y15wHd+6Cs1qkE,iv:9+dsrIe0t7bXLVq/IHYuXFk90DSOhvcQvMil85MMf38=,tag:jH2rwqXFYQOXyW7+RBMIag==,type:str]
     SECRET_ALERTMANAGER_DEADMAN_URL: ENC[AES256_GCM,data:9wo6IJFkTA0/xgJmrDFODvgHX9zPlD+R6EKTTH6RAor5KNhtjGSPneVOxwFp61IlXY3hYIkQX00=,iv:dOrp0v90mYIgDcjbXmLFCPjX6/wX0WyPjQohtlEkgPY=,tag:IRBr5JZYHqyOUxNxG0xL7Q==,type:str]
     VLLM_DELL_HOST: ENC[AES256_GCM,data:BqY3neFZVZktJjE=,iv:OOo2sH2UQof/FhEZpRS4eg6UOGONE8chWlkcw1Zvks0=,tag:m7Cy3O+dUgg68IVvOXjV6w==,type:str]
+    VLLM_GX10_HOST: ENC[AES256_GCM,data:PTfP/t71CK7E+IQ=,iv:ega6N3hiR4V6ubaMngyUiVjXG6kaJUZop/ktd6oJOFk=,tag:AZfz6NoB0uY3+uF2YihBwQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2026-08-20T22:44:11Z"
-    mac: ENC[AES256_GCM,data:nM9JdpS5Ax6CoLdpoSE2Y9aIwpntilOgFFc+NTRWeQx0OyD/8sMu1QyXPZ3prfx/7N5fiX3m6ye68/eztSe4pdWlC73lDVdmiVB7LaJjF8+ihwd6iZXcFoNqYt+dZdUWsLhGoSZqR/gFIL+qTJyiLkRrlJO47vdqr7GJAMrtN2w=,iv:EaFzBLFbY+W6ApVARfWoiCu4p2yvpy5bE3Gkk4umkIQ=,tag:E8EMsMJ76gpmauMRNYfCxw==,type:str]
+    lastmodified: "2026-08-23T21:20:02Z"
+    mac: ENC[AES256_GCM,data:plcSQqvQod9LWZssfXJPRLSR3Utg8jDB6Pko/w641cYQImt30TbpPdj8XvKdifxStpPOSTxCzlMvMuGS0+5kEVa/6VAybodU97HSsKAYGoDjm8j3WtUUsYNtKa1027OYkweBAKad4kWgPG8e5xsugRQJkHfgvmgcpPChGwsLTK0=,iv:5IOkXCf33HFNOz9pqWe/q1/GRyHNw3LIJqxFs1EHJqI=,tag:DWFPK/yGwHqHE/BRBAUMUA==,type:str]
     pgp:
         - created_at: "2021-04-27T01:36:09Z"
           enc: |


### PR DESCRIPTION
Adds a `ScrapeConfig` for the router's Prometheus endpoint plus a vendored Grafana dashboard.

The router currently splits traffic evenly across two local models. These metrics are what turn that split into a comparison — decisions and completion tokens per model, and response outcomes — accumulated from real use rather than a hand-built benchmark.

## Panels

- share of decisions by model over the range
- decision rate by model
- completion tokens/sec by model
- responses by outcome (success / retryable / other)

## Two things that would otherwise fail silently

- **`release: kube-prometheus-stack` is required.** The Prometheus CR's `scrapeConfigSelector` matches on it; a ScrapeConfig without the label is ignored with no error logged anywhere.
- **Series colours are pinned by name**, not left to the palette. Grafana's classic palette assigns by query order, so a model with no traffic in the window would shift the other one's colour between panels. The pair was validated for contrast and colour-vision separation against the dark surface.

## Other

`VLLM_GX10_HOST` added to cluster-secrets for the target address, via SOPS EDITOR mode so the diff is the new key rather than a full re-encrypt.

First `ScrapeConfig` in the repo — the CRD is served and `scrapeConfigNamespaceSelector` is already `{}`, so no operator change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW