### PR TITLE
fix(switchyard): escape grafana template vars from flux envsubst

### DIFF
--- a/cluster/apps/ai/switchyard/app/dashboards/switchyard.json
+++ b/cluster/apps/ai/switchyard/app/dashboards/switchyard.json
@@ -27,11 +27,11 @@
       "title": "Share of decisions by model",
       "description": "Which backend actually served, over the dashboard time range. With the random route this should track the configured weights; drift means something else is selecting.",
       "gridPos": { "h": 6, "w": 12, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "expr": "sum by (selected_model) (increase(switchyard_decisions_total{job=\"switchyard\"}[$__range]))",
           "legendFormat": "{{selected_model}}",
           "instant": true
@@ -81,11 +81,11 @@
       "title": "Responses by outcome",
       "description": "Errors are the half of an A/B that a clean benchmark never shows.",
       "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "expr": "sum by (outcome) (rate(switchyard_client_responses_total{job=\"switchyard\"}[5m]))",
           "legendFormat": "{{outcome}}"
         }
@@ -139,11 +139,11 @@
       "title": "Decision rate by model",
       "description": "Routing decisions per second, split by the model selected.",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "expr": "sum by (selected_model) (rate(switchyard_decisions_total{job=\"switchyard\"}[5m]))",
           "legendFormat": "{{selected_model}}"
         }
@@ -188,11 +188,11 @@
       "title": "Completion tokens per second by model",
       "description": "Work done, not requests served. A model can win on decisions and lose here.",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
           "expr": "sum by (model) (rate(switchyard_completion_tokens_total{job=\"switchyard\"}[5m]))",
           "legendFormat": "{{model}}"
         }


### PR DESCRIPTION
The dashboard Kustomization was failing to build:

```
post build failed for 'ConfigMap.v1.[noGrp]/grafana-dashboards-switchyard':
envsubst error: variable substitution failed: variable not set (strict mode): "datasource"
```

Grafana's template-variable syntax (`${datasource}`) is the same as Flux's postBuild substitution syntax, so Flux tried to resolve it and failed in strict mode. `$${var}` passes through as a literal `${var}`, leaving Grafana to resolve it at render time.

Eight occurrences — one per panel datasource reference plus the panel targets.

Worth knowing for any future vendored dashboard: this bites any Grafana JSON with template variables that lands under `cluster/apps`, since substitution is patched onto every Kustomization there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW