### PR TITLE
feat(radicale): mirror the school lunch menu onto the family calendar

### DIFF
--- a/cluster/apps/radicale/kustomization.yaml
+++ b/cluster/apps/radicale/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./radicale/ks.yaml
   - ./proton-mirror/ks.yaml
   - ./mealie-mirror/ks.yaml
+  - ./school-lunch-mirror/ks.yaml
   - ./netpol

--- a/cluster/apps/radicale/school-lunch-mirror/app/helm-release.yaml
+++ b/cluster/apps/radicale/school-lunch-mirror/app/helm-release.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: school-lunch-mirror
+  namespace: radicale
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  values:
+    controllers:
+      school-lunch-mirror:
+        type: cronjob
+        cronjob:
+          # Daily: menus are published weeks ahead, so this is about noticing
+          # revisions rather than fetching anything new.
+          schedule: "12 5 * * *"
+          suspend: false
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 2
+        containers:
+          app:
+            image:
+              repository: python
+              tag: 3.13-slim@sha256:9662417aace5ae7b8e2609cce472b72a8958e134ba372808abe9cc1a0c0125e6
+            command: ["python", "/app/school_lunch_mirror.py"]
+            env:
+              RADICALE_URL: http://radicale.radicale.svc.cluster.local:5232
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    persistence:
+      script:
+        type: configMap
+        name: school-lunch-mirror-configmap
+        globalMounts:
+          - path: /app/school_lunch_mirror.py
+            subPath: school_lunch_mirror.py
+            readOnly: true
+      config:
+        type: secret
+        name: school-lunch-mirror-secret
+        globalMounts:
+          - path: /config/config.json
+            subPath: config.json
+            readOnly: true

--- a/cluster/apps/radicale/school-lunch-mirror/app/kustomization.yaml
+++ b/cluster/apps/radicale/school-lunch-mirror/app/kustomization.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: radicale
+resources:
+  - ./secret.sops.yaml
+  - ./helm-release.yaml
+configMapGenerator:
+  - name: school-lunch-mirror-configmap
+    files:
+      - school_lunch_mirror.py=./resources/school_lunch_mirror.py
+    options:
+      disableNameSuffixHash: true

--- a/cluster/apps/radicale/school-lunch-mirror/app/resources/school_lunch_mirror.py
+++ b/cluster/apps/radicale/school-lunch-mirror/app/resources/school_lunch_mirror.py
@@ -71,6 +71,7 @@ def http(method, url, auth=None, body=None, headers=None):
             if attempt == 3 or not isinstance(err.reason, ConnectionRefusedError):
                 raise
             time.sleep(2 * (attempt + 1))
+    raise RuntimeError(f"{method} {url}: retries exhausted")
 
 
 def unfold(text):
@@ -103,6 +104,55 @@ def ical_escape(text):
     )
 
 
+def day_dishes(day):
+    """One published day -> (title items, 'Category: a, b' detail lines)."""
+    titles, detail = [], []
+    for meal in day.get("MenuMeals") or []:
+        for category in meal.get("RecipeCategories") or []:
+            name = (category.get("CategoryName") or "").strip()
+            items = [
+                (recipe.get("RecipeName") or "").strip()
+                for recipe in category.get("Recipes") or []
+                if (recipe.get("RecipeName") or "").strip()
+            ]
+            if not items:
+                continue
+            if name in TITLE_CATEGORIES:
+                titles.extend(items)
+            detail.append(f"{name}: {', '.join(items)}")
+    return titles, detail
+
+
+def day_event(date, titles, detail):
+    """Build the all-day VEVENT lines for one menu day."""
+    summary = f"{SESSION}: " + (" / ".join(titles[:3]) if titles else "see description")
+    next_day = (date + datetime.timedelta(days=1)).strftime("%Y%m%d")
+    lines = [
+        "BEGIN:VEVENT",
+        f"UID:lunch-{date.strftime('%Y%m%d')}@school-lunch-mirror",
+        f"DTSTART;VALUE=DATE:{date.strftime('%Y%m%d')}",
+        f"DTEND;VALUE=DATE:{next_day}",
+        f"SUMMARY:{ical_escape(summary)}",
+        "TRANSP:TRANSPARENT",
+        "END:VEVENT",
+    ]
+    if detail:
+        lines.insert(-1, f"DESCRIPTION:{ical_escape(chr(10).join(detail))}")
+    return lines
+
+
+def published_days(payload):
+    """Yield (date, day) for every day of the configured serving session."""
+    for session in payload.get("FamilyMenuSessions") or []:
+        if (session.get("ServingSession") or "").strip() != SESSION:
+            continue
+        for plan in session.get("MenuPlans") or []:
+            for day in plan.get("Days") or []:
+                raw = day.get("Date")
+                if raw:
+                    yield datetime.datetime.strptime(raw, "%m/%d/%Y").date(), day
+
+
 def fetch_menu(config, start, end):
     """Fetch the published menu -> {uid: (hash, vevent lines, date)}."""
     url = (
@@ -114,51 +164,15 @@ def fetch_menu(config, start, end):
     status, body = http("GET", url, headers={"User-Agent": BROWSER_UA})
     if status != 200:
         raise RuntimeError(f"menu fetch -> {status}")
-    payload = json.loads(body)
 
     events = {}
-    for session in payload.get("FamilyMenuSessions") or []:
-        if (session.get("ServingSession") or "").strip() != SESSION:
+    for date, day in published_days(json.loads(body)):
+        titles, detail = day_dishes(day)
+        if not titles and not detail:
             continue
-        for plan in session.get("MenuPlans") or []:
-            for day in plan.get("Days") or []:
-                raw = day.get("Date")
-                if not raw:
-                    continue
-                date = datetime.datetime.strptime(raw, "%m/%d/%Y").date()
-                titles, detail = [], []
-                for meal in day.get("MenuMeals") or []:
-                    for category in meal.get("RecipeCategories") or []:
-                        name = (category.get("CategoryName") or "").strip()
-                        items = [
-                            (r.get("RecipeName") or "").strip()
-                            for r in category.get("Recipes") or []
-                            if (r.get("RecipeName") or "").strip()
-                        ]
-                        if not items:
-                            continue
-                        if name in TITLE_CATEGORIES:
-                            titles.extend(items)
-                        detail.append(f"{name}: {', '.join(items)}")
-                if not titles and not detail:
-                    continue
-                summary = f"{SESSION}: " + (
-                    " / ".join(titles[:3]) if titles else "see description"
-                )
-                uid = f"lunch-{date.strftime('%Y%m%d')}@school-lunch-mirror"
-                lines = [
-                    "BEGIN:VEVENT",
-                    f"UID:{uid}",
-                    f"DTSTART;VALUE=DATE:{date.strftime('%Y%m%d')}",
-                    f"DTEND;VALUE=DATE:{(date + datetime.timedelta(days=1)).strftime('%Y%m%d')}",
-                    f"SUMMARY:{ical_escape(summary)}",
-                    "TRANSP:TRANSPARENT",
-                    "END:VEVENT",
-                ]
-                if detail:
-                    lines.insert(-1, f"DESCRIPTION:{ical_escape(chr(10).join(detail))}")
-                digest = hashlib.sha256("\n".join(lines).encode()).hexdigest()[:16]
-                events[uid] = (digest, lines, date)
+        lines = day_event(date, titles, detail)
+        digest = hashlib.sha256("\n".join(lines).encode()).hexdigest()[:16]
+        events[prop_value(lines, "UID")] = (digest, lines, date)
     return events
 
 

--- a/cluster/apps/radicale/school-lunch-mirror/app/resources/school_lunch_mirror.py
+++ b/cluster/apps/radicale/school-lunch-mirror/app/resources/school_lunch_mirror.py
@@ -1,0 +1,285 @@
+"""Mirror the school lunch menu into a Radicale calendar.
+
+The district publishes menus through LINQ Connect; this job projects the
+lunch session onto the shared family calendar as all-day entries. Stateless
+in the same way as the Mealie mirror: every event carries an
+X-SCHOOL-LUNCH-MIRROR property with a content hash, so each run identifies
+its own events, updates changed ones, and deletes entries that disappear
+from the published menu — without touching events created directly in
+Radicale.
+
+Days absent from the API get no event, which is how closures and holidays
+handle themselves: AcademicCalendars comes back empty for this district, so
+absence of a menu is the only closure signal available.
+
+Config: config.json — {"district_id", "building_id", "user", "password",
+"collection"}; MIRROR_CONFIG, RADICALE_URL and DRY_RUN come from the
+environment. The IDs live in the secret rather than the manifest because
+together they identify which school a child attends.
+"""
+
+import base64
+import datetime
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.request
+import xml.etree.ElementTree as ET
+
+RADICALE_URL = os.environ.get(
+    "RADICALE_URL", "http://radicale.radicale.svc.cluster.local:5232"
+)
+MENU_API = os.environ.get("MENU_API", "https://api.linqconnect.com/api/FamilyMenu")
+DRY_RUN = os.environ.get("DRY_RUN", "") == "1"
+MARKER = "X-SCHOOL-LUNCH-MIRROR"
+SESSION = os.environ.get("SERVING_SESSION", "Lunch")
+WINDOW_PAST = int(os.environ.get("WINDOW_PAST", "3"))
+WINDOW_FUTURE = int(os.environ.get("WINDOW_FUTURE", "30"))
+# Categories worth naming in the event title. Everything else (milk, the
+# standing fruit and vegetable bars) is noise on a calendar and lands in the
+# description instead.
+TITLE_CATEGORIES = ("Main Entree",)
+# The upstream endpoint 403s a bare urllib User-Agent.
+BROWSER_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+)
+
+
+def http(method, url, auth=None, body=None, headers=None):
+    """One-shot HTTP request; returns (status, body bytes).
+
+    Retries connection-refused a few times: a fresh job pod's IP takes a
+    moment to land in kube-router's netpol ipsets, so the first packets
+    to in-cluster services can bounce.
+    """
+    req = urllib.request.Request(url, method=method, data=body)
+    if auth is not None:
+        token = base64.b64encode(f"{auth[0]}:{auth[1]}".encode()).decode()
+        req.add_header("Authorization", f"Basic {token}")
+    for key, value in (headers or {}).items():
+        req.add_header(key, value)
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return resp.status, resp.read()
+        except urllib.error.HTTPError as err:
+            return err.code, err.read()
+        except urllib.error.URLError as err:
+            if attempt == 3 or not isinstance(err.reason, ConnectionRefusedError):
+                raise
+            time.sleep(2 * (attempt + 1))
+
+
+def unfold(text):
+    """Unfold RFC 5545 folded lines."""
+    out = []
+    for line in text.replace("\r\n", "\n").split("\n"):
+        if line[:1] in (" ", "\t") and out:
+            out[-1] += line[1:]
+        else:
+            out.append(line)
+    return out
+
+
+def prop_value(block, name):
+    """Value of the first property `name` in an unfolded component block."""
+    for line in block:
+        upper = line.upper()
+        if upper.startswith(name.upper() + ":") or upper.startswith(name.upper() + ";"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def ical_escape(text):
+    """Escape a value for an iCalendar TEXT property."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\n", "\\n")
+    )
+
+
+def fetch_menu(config, start, end):
+    """Fetch the published menu -> {uid: (hash, vevent lines, date)}."""
+    url = (
+        f"{MENU_API}?buildingId={config['building_id']}"
+        f"&districtId={config['district_id']}"
+        f"&startDate={start.strftime('%-m-%-d-%Y')}"
+        f"&endDate={end.strftime('%-m-%-d-%Y')}"
+    )
+    status, body = http("GET", url, headers={"User-Agent": BROWSER_UA})
+    if status != 200:
+        raise RuntimeError(f"menu fetch -> {status}")
+    payload = json.loads(body)
+
+    events = {}
+    for session in payload.get("FamilyMenuSessions") or []:
+        if (session.get("ServingSession") or "").strip() != SESSION:
+            continue
+        for plan in session.get("MenuPlans") or []:
+            for day in plan.get("Days") or []:
+                raw = day.get("Date")
+                if not raw:
+                    continue
+                date = datetime.datetime.strptime(raw, "%m/%d/%Y").date()
+                titles, detail = [], []
+                for meal in day.get("MenuMeals") or []:
+                    for category in meal.get("RecipeCategories") or []:
+                        name = (category.get("CategoryName") or "").strip()
+                        items = [
+                            (r.get("RecipeName") or "").strip()
+                            for r in category.get("Recipes") or []
+                            if (r.get("RecipeName") or "").strip()
+                        ]
+                        if not items:
+                            continue
+                        if name in TITLE_CATEGORIES:
+                            titles.extend(items)
+                        detail.append(f"{name}: {', '.join(items)}")
+                if not titles and not detail:
+                    continue
+                summary = f"{SESSION}: " + (
+                    " / ".join(titles[:3]) if titles else "see description"
+                )
+                uid = f"lunch-{date.strftime('%Y%m%d')}@school-lunch-mirror"
+                lines = [
+                    "BEGIN:VEVENT",
+                    f"UID:{uid}",
+                    f"DTSTART;VALUE=DATE:{date.strftime('%Y%m%d')}",
+                    f"DTEND;VALUE=DATE:{(date + datetime.timedelta(days=1)).strftime('%Y%m%d')}",
+                    f"SUMMARY:{ical_escape(summary)}",
+                    "TRANSP:TRANSPARENT",
+                    "END:VEVENT",
+                ]
+                if detail:
+                    lines.insert(-1, f"DESCRIPTION:{ical_escape(chr(10).join(detail))}")
+                digest = hashlib.sha256("\n".join(lines).encode()).hexdigest()[:16]
+                events[uid] = (digest, lines, date)
+    return events
+
+
+def wrap_event(ev_lines, digest):
+    """Wrap one VEVENT into a marked VCALENDAR."""
+    event = list(ev_lines)
+    event.insert(-1, f"{MARKER}:{digest}")
+    body = ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//school-lunch-mirror//EN"]
+    body.extend(event)
+    body.append("END:VCALENDAR")
+    return "\r\n".join(body) + "\r\n"
+
+
+def existing_mirrored(base, auth):
+    """REPORT the collection -> {uid: (href, digest, date)} for mirror-owned items."""
+    report = (
+        '<?xml version="1.0" encoding="utf-8" ?>'
+        '<C:calendar-query xmlns:D="DAV:" '
+        'xmlns:C="urn:ietf:params:xml:ns:caldav">'
+        "<D:prop><C:calendar-data/></D:prop>"
+        '<C:filter><C:comp-filter name="VCALENDAR">'
+        '<C:comp-filter name="VEVENT"/></C:comp-filter></C:filter>'
+        "</C:calendar-query>"
+    )
+    status, body = http(
+        "REPORT",
+        base,
+        auth,
+        report.encode(),
+        {"Content-Type": "application/xml", "Depth": "1"},
+    )
+    if status != 207:
+        raise RuntimeError(f"REPORT {base} -> {status}")
+    out = {}
+    namespaces = {"D": "DAV:", "C": "urn:ietf:params:xml:ns:caldav"}
+    for resp in ET.fromstring(body).findall("D:response", namespaces):
+        href = resp.findtext("D:href", namespaces=namespaces)
+        data = resp.findtext(".//C:calendar-data", namespaces=namespaces) or ""
+        lines = unfold(data)
+        digest = prop_value(lines, MARKER)
+        uid = prop_value(lines, "UID")
+        raw_start = (prop_value(lines, "DTSTART") or "").split("T")[0]
+        try:
+            day = datetime.datetime.strptime(raw_start, "%Y%m%d").date()
+        except ValueError:
+            day = None
+        if digest and uid:
+            out[uid] = (href, digest, day)
+    return out
+
+
+def upsert_events(base, auth, events, mirrored):
+    """PUT new/changed menu events; returns (created, updated, kept)."""
+    created = updated = kept = 0
+    for uid, (digest, event, _) in events.items():
+        if uid in mirrored and mirrored[uid][1] == digest:
+            kept += 1
+            continue
+        action = "update" if uid in mirrored else "create"
+        safe = hashlib.sha256(uid.encode()).hexdigest()[:32]
+        if DRY_RUN:
+            print(f"DRY: {action} {uid} :: {prop_value(event, 'SUMMARY')}")
+        else:
+            status, _ = http(
+                "PUT",
+                f"{base}lunch-{safe}.ics",
+                auth,
+                wrap_event(event, digest).encode(),
+                {"Content-Type": "text/calendar"},
+            )
+            if status not in (200, 201, 204):
+                print(f"WARN: PUT {uid} -> {status}", file=sys.stderr)
+                continue
+        created += action == "create"
+        updated += action == "update"
+    return created, updated, kept
+
+
+def delete_removed(auth, events, mirrored, start):
+    """DELETE mirror-owned events dropped from the menu; returns count.
+
+    Events dated before the sync window are kept — the windowed fetch can't
+    see them, so their absence proves nothing.
+    """
+    deleted = 0
+    for uid, (href, _, day) in mirrored.items():
+        if uid in events:
+            continue
+        if day is not None and day < start:
+            continue
+        if DRY_RUN:
+            print(f"DRY: delete {uid}")
+        else:
+            status, _ = http("DELETE", f"{RADICALE_URL}{href}", auth)
+            if status not in (200, 204):
+                print(f"WARN: DELETE {uid} -> {status}", file=sys.stderr)
+                continue
+        deleted += 1
+    return deleted
+
+
+def main():
+    """Sync the published menu window into the configured collection."""
+    path = os.environ.get("MIRROR_CONFIG", "/config/config.json")
+    with open(path, encoding="utf-8") as handle:
+        config = json.load(handle)
+    base = f"{RADICALE_URL}{config['collection']}"
+    auth = (config["user"], config["password"])
+    today = datetime.date.today()
+    start = today - datetime.timedelta(days=WINDOW_PAST)
+    end = today + datetime.timedelta(days=WINDOW_FUTURE)
+
+    events = fetch_menu(config, start, end)
+    mirrored = existing_mirrored(base, auth)
+    created, updated, kept = upsert_events(base, auth, events, mirrored)
+    deleted = delete_removed(auth, events, mirrored, start)
+    print(
+        f"{config['collection']}: {len(events)} menu days | "
+        f"+{created} ~{updated} -{deleted} ={kept}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cluster/apps/radicale/school-lunch-mirror/app/secret.sops.yaml
+++ b/cluster/apps/radicale/school-lunch-mirror/app/secret.sops.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: school-lunch-mirror-secret
+    namespace: radicale
+stringData:
+    config.json: ENC[AES256_GCM,data:oS3e6nSnK+bGpGVIbhiEZXH9DdxgnVA0MsyOss4dH/c30I647/psKo3SIqprSkrvmU0xK8w0akOg3TWCzB451fG2O6oeYGL4U0Gljg/6Atguy9RfDf1qpYBll6cnN3mCoL9S7R+wai6jU2Tj710rtF/+E4E5fuWCcZ8GDF1SSt5266SaAVzKetHOlImtnUlsK+9WZ2B8nyv/ATFIVpJzLJJHHzUPTFstIHz+sS9FQWFkKlCDUzzbblDneT/Y48NxLbs806DZmx+rpMFCXZPxQyLW,iv:I+8qUD13vk5eS/4BQYnvjcPNRKnZr5IZIixLgJSp9u0=,tag:to1W9I4BkFD2Qz4qnH1LVQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-08-24T22:36:49Z"
+    mac: ENC[AES256_GCM,data:yxuPRwy+91nLG+iLAms8voFJxyJ87d4cc2t6NKQS/dLOEhRglwRBLJciHn6wd1I7XmEeEikAA/x8dtasQ90nTErltaWe7qmh97O9gu8IFq5Zwlo1EsfjfoUalFwg/fAONQpqtv0W8QtnteQl1Bj84mv0uDqLkj6OHDX8bz0WqWc=,iv:1c9J9wpf27ntnZvZ7vYqOF3cHiCoTGj6364UWdG0e9w=,tag:7pXKR5J+JKQQ372oiakO7g==,type:str]
+    pgp:
+        - created_at: "2026-08-24T22:36:48Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0dSZMvnEisuARAAtQbrmUYzftzTCTcprNc7A8n4ROi6zt3UEcjI2Yy4yPVB
+            vsocCCpkvMai7eCxgmciMHion4OaMFvUXmA15sXd9cB2mpXsADvjoVQsV7qGXipp
+            ITfo0lqcj+4eet+UKP2UDr+W8vh4GkimvzCXzGyCyDR9qHiF7xCdzOzvaBHbPXiT
+            gansez1jCiIIwjI36mwDbQUB398DOALaiRSq6hI295av7WVZeJriJ5QnOZuxbLIk
+            Bjmm6L8U3SYgXrCx1tu2IInmNixXPBiWc/k1WCvwcyv7DCP4GpQF99SZda/6pUbY
+            PNG38HF17WKqm95Y9LIi3zkkwsaTHOtnLZrSa1AfJUSukxDeH5dvNRf1tUqkNlrs
+            LeavSE7d5uaoqQ/6Xkgy+MTyj+VigeIk8TIv9SktAWgipEhgIKXV+AwU/q2jazQ7
+            foJRYkhF20/iTIxGx9bqyXfYDVexbQOs5cnvLYRaPUBMRvD7Th2G8HC8zNoibf4S
+            3ATpCAIP7pod7f8YHRxULk5GXjPSzGjWru7uLT/MdVFsUbN3ScgRM/aUb9KIG9Bm
+            3/6Ce8w+bDC8x8h2npZaAeb/nOejC7Y6cq26LOJIJeRNnE8K6ma2if5COgsJWbQE
+            9qe+sT7VcGaZNaTvtisN26pHE9ZzSPYzkRlTJHuwAqMQ+xQLjkmJwZ9ewNxfTl7S
+            XgGRwYQYRcn6BDRxsdubDtSuBYZ2A2VJOrWzNVnqcd3/FY9bfe4XcYsF7oS6QnXa
+            eP4ytkoX8NcI6TMP4mejGnbuPMUiC+NySZlkDXhdq5XpguKcrXx4VQxGVGW01Ng=
+            =UGsh
+            -----END PGP MESSAGE-----
+          fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
+        - created_at: "2026-08-24T22:36:48Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAxbwxdi5IniFAQ//Qln7l+syhPD/SbJyg9hZwarUaCzMC51If36Y8eGNb6RQ
+            Qdkejvw98um9oXywMZ9SW4c6JvFFxqsCNZ5M4qn3Z2F3+wqKo9JIkOmbUriWbSJa
+            9ZAGCG5Imh74X+5ZZEgUzysvqpTICISjKtMMMsh+KZGlcLX/XioJ6e0M7FVG759O
+            NMVC9U0JsgF0PjlNb4mGVoTIpy7O2Dd2otC8sVA5Fi79WBXZtmw1H6lFtK9tyZ/0
+            u8/fiL2X2HgEBfPCvg0n+QfCYqB737bOOOIEB53Vk6AS/eluD6caJU5EsFbbld98
+            ceBVN7Pzlh8gmHC1gwWCwp3Pnge4jySrZ3JXocqCc5TdCy4Yt50FwphzcUsuwWex
+            DbFmxD42HLrJV54fh9HiTXOxPNJFwSLVjetrPE6nHZNsIDG6xRn+zCd7sdzIbFNY
+            USEuUWuIKjnvh08yfVC2pugl4lx2kUorFBy6l6QyJ3lXU9zRTNl64jDzlYsQKV8v
+            Jme5KiLWePH9+Y207UxXhTDyq6KMziYl+JcMc7x2IoZP17iiK+BaLwvN7CjZG/FM
+            R6ct38eGxMfpjRt57y6Pz6hGHBYs4uCii9DWzrQbZXdJ9XiMtlNYWY4Tu62qSUu3
+            t6cx3pHNkawp6tvbv75lqApCX5n+rWqwNAZoYsEolRWVGnwu4NZFQ5fxz/OVQN/S
+            XgHwFZEKrN9QsYD7gGF/TBvEjJjzubB0cBfg8MVGF3r+Y+lTCO7OwgbYATpyYbxw
+            YFKgsfj7Pg2+YXy7x+mKu0CtuPu8mTYBYifTQHnIFqTdvKQsfscB5XrRd2aTT58=
+            =9VZn
+            -----END PGP MESSAGE-----
+          fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/cluster/apps/radicale/school-lunch-mirror/ks.yaml
+++ b/cluster/apps/radicale/school-lunch-mirror/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-school-lunch-mirror
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/radicale/school-lunch-mirror/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Projects the published elementary lunch menu onto the shared family calendar as all-day entries, so it appears in everyone's phone calendar next to real events.

Same shape as the mealie mirror — CronJob, configMap-mounted script, stateless. Every event carries an `X-SCHOOL-LUNCH-MIRROR` content hash, so a run identifies its own events, updates changed ones and deletes withdrawn ones without touching anything created directly in Radicale.

## Verified against the live API

21 menu days parsed over a 33-day window:

```
2026-08-24  Lunch: Chicken Patty Sandwich / Spicy Chicken Patty Sandwich / Cheese Pizza
2026-08-25  Lunch: Breaded Mozzarella Cheese Sticks, WG / Tuna Salad w/Pita Bread / ...
2026-08-26  Lunch: Three Cheese Cavatappi / Cheese Pizza / Pepperoni Pizza
```

## Notes on the upstream API, which is undocumented

- it **403s a bare urllib User-Agent**, so the fetch sends a browser one
- **days absent from the response get no event** — that is how closures and holidays handle themselves, since the `AcademicCalendars` field comes back empty for this district and absence of a menu is the only closure signal available
- only `Main Entree` items go in the title; the standing fruit, vegetable and milk options are noise on a calendar and land in the description instead

## Privacy

The building and district identifiers live in the secret rather than the manifest. They are not credentials, but together they identify which school a child attends, and this repository is public.

## Rollout

Suggest running once with `DRY_RUN=1` before the first scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW