### PR TITLE
feat(vllm): scrape the engines and ship a dashboard

### DIFF
--- a/cluster/apps/ai/kustomization.yaml
+++ b/cluster/apps/ai/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./litellm/ks.yaml
   - ./llamacpp/ks.yaml
   - ./switchyard/ks.yaml
+  - ./vllm-metrics/ks.yaml
   - ./netpol

--- a/cluster/apps/ai/vllm-metrics/app/dashboards/vllm-engines.json
+++ b/cluster/apps/ai/vllm-metrics/app/dashboards/vllm-engines.json
@@ -1,0 +1,221 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "title": "vLLM engines",
+  "uid": "vllm-engines",
+  "tags": ["ai", "vllm"],
+  "timezone": "browser",
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Memory bandwidth in use",
+      "description": "Bytes read from memory per second. The GB10 boxes have roughly 273 GB/s of bus; the 3090 roughly 936. Generation on these models is bandwidth-bound, so this is the number that decides throughput.",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+          "expr": "sum by (box, served) (rate(vllm:estimated_read_bytes_per_gpu_total{job=\"vllm\"}[5m]))",
+          "legendFormat": "{{box}} · {{served}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["max", "mean"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "KV cache in use",
+      "description": "Fraction of each engine's reserved KV cache actually holding tokens. Capacity in tokens is in the table below - a low number here means the reservation is larger than the workload needs.",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+          "expr": "vllm:kv_cache_usage_perc{job=\"vllm\"}",
+          "legendFormat": "{{box}} · {{served}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["max", "mean"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "lineWidth": 2, "fillOpacity": 8, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Speculative decoding — accepted / drafted",
+      "description": "MTP earns its keep only when drafts are accepted. A rejected draft token costs compute and returns nothing, so a falling ratio is the signal to lower num_speculative_tokens.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+          "expr": "sum by (box, served) (rate(vllm:spec_decode_num_accepted_tokens_total{job=\"vllm\"}[15m])) / sum by (box, served) (rate(vllm:spec_decode_num_draft_tokens_total{job=\"vllm\"}[15m]))",
+          "legendFormat": "{{box}} · {{served}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests queued for capacity",
+      "description": "Requests waiting because KV cache is full, rather than because the engine is busy. This is the only evidence that a reservation is actually too small - if it stays at zero, headroom is not the constraint.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+          "expr": "sum by (box, served) (vllm:num_requests_waiting_by_reason{job=\"vllm\", reason=\"capacity\"})",
+          "legendFormat": "{{box}} · {{served}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+          "expr": "sum by (box, served) (vllm:num_requests_running{job=\"vllm\"})",
+          "legendFormat": "running — {{box}} · {{served}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["max"]
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": { "lineWidth": 2, "fillOpacity": 12, "showPoints": "never" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "table",
+      "title": "What each engine reserved",
+      "description": "Straight from vLLM's own cache_config_info. These are the carve-out facts: how much of the device was claimed, and what that bought in tokens and concurrent full-context requests.",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 17 },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "$${datasource}" },
+          "expr": "vllm:cache_config_info{job=\"vllm\"}",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "engine": true,
+              "container": true,
+              "endpoint": true,
+              "namespace": true,
+              "pod": true,
+              "service": true,
+              "_block_size_resolved": true,
+              "cache_dtype": true,
+              "kv_cache_dtype_skip_layers": true,
+              "kv_cache_memory_bytes": true,
+              "calculate_kv_scales": true,
+              "enable_prefix_caching": true,
+              "cpu_offload_gb": true,
+              "is_attention_free": true,
+              "num_cpu_blocks": true,
+              "sliding_window": true,
+              "swap_space_bytes": true
+            },
+            "renameByName": {
+              "box": "Box",
+              "served": "Model",
+              "gpu_memory_utilization": "Device reserved",
+              "kv_cache_size_tokens": "KV capacity (tokens)",
+              "kv_cache_max_concurrency": "Concurrent full-context requests",
+              "block_size": "Block size",
+              "num_gpu_blocks": "GPU blocks"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "left" } },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/cluster/apps/ai/vllm-metrics/app/kustomization.yaml
+++ b/cluster/apps/ai/vllm-metrics/app/kustomization.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./scrapeconfig.yaml
+  - ./servicemonitor.yaml
+configMapGenerator:
+  - name: grafana-dashboards-vllm
+    namespace: monitoring
+    files:
+      - dashboards/vllm-engines.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+      disableNameSuffixHash: true

--- a/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
+++ b/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
@@ -1,0 +1,27 @@
+---
+# vLLM serves Prometheus natively on its API port -- no exporter involved.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: vllm-hosts
+  namespace: ai
+  labels:
+    # The Prometheus CR's scrapeConfigSelector matches this; without it the
+    # config is ignored and nothing is logged.
+    release: kube-prometheus-stack
+spec:
+  metricsPath: /metrics
+  scrapeInterval: 30s
+  staticConfigs:
+    - targets:
+        - "${VLLM_DELL_HOST}:8000"
+      labels: { job: vllm, box: gb10, served: nemotron35-lightning }
+    - targets:
+        - "${VLLM_DELL_HOST}:8001"
+      labels: { job: vllm, box: gb10, served: qwen38-27b }
+    - targets:
+        - "${VLLM_GX10_HOST}:8000"
+      labels: { job: vllm, box: gx10, served: nemotron35-lightning }
+    - targets:
+        - "${VLLM_GX10_HOST}:8001"
+      labels: { job: vllm, box: gx10, served: qwen38-27b }

--- a/cluster/apps/ai/vllm-metrics/app/servicemonitor.yaml
+++ b/cluster/apps/ai/vllm-metrics/app/servicemonitor.yaml
@@ -1,0 +1,31 @@
+---
+# The in-cluster engines. Same native metrics as the standalone hosts, reached
+# through their services. Selects on the component rather than one model, so a
+# model swap keeps reporting without a manifest change; `served` comes from the
+# service's own label instead of being hardcoded.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: vllm-engines
+  namespace: ai
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames: [ai]
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: serving-engine
+  endpoints:
+    - port: service-port
+      path: /metrics
+      interval: 30s
+      relabelings:
+        # Match the job label the standalone hosts carry, so one query spans all
+        # engines regardless of where they run.
+        - targetLabel: job
+          replacement: vllm
+        - targetLabel: box
+          replacement: "3090"
+        - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+          targetLabel: served

--- a/cluster/apps/ai/vllm-metrics/ks.yaml
+++ b/cluster/apps/ai/vllm-metrics/ks.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-vllm-metrics
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/ai/vllm-metrics/app
+  dependsOn:
+    - name: cluster-apps-kube-prometheus-stack
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
vLLM serves Prometheus **natively** on its API port — no exporter involved. 96 metric families were already being published and none of them collected.

## What's here

- `ScrapeConfig` for the four standalone endpoints, labelled by box and served model
- `ServiceMonitor` for the in-cluster engines
- Dashboard: memory bandwidth in use, KV cache utilisation, speculative-decoding acceptance, requests queued for capacity, and a table of what each engine actually reserved

## Two arguments this settles with data

**Whether speculative decoding earns its keep.** A rejected draft token costs compute and returns nothing, so `accepted / drafted` is what should decide `num_speculative_tokens` — measured on real traffic rather than inferred from one hand-run benchmark.

**Whether a reservation is too small.** `num_requests_waiting_by_reason{reason="capacity"}` is the only real evidence. If it stays at zero, headroom isn't the constraint however tight the arithmetic looks.

## Notes

The ServiceMonitor selects on the `serving-engine` component rather than one model, and takes the model name from the service's own label, so a model swap keeps reporting without a manifest change. Verified against the live service — my first guess at the selector was the service name, which would have matched nothing and scraped silently.

Both objects carry `release: kube-prometheus-stack`; without it the Prometheus CR ignores them with nothing logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW