### PR TITLE
fix(syncthing): raise the memory limit off its ceiling

### DIFF
--- a/cluster/apps/syncthing/syncthing/app/helm-release.yaml
+++ b/cluster/apps/syncthing/syncthing/app/helm-release.yaml
@@ -44,10 +44,16 @@ spec:
             resources:
               requests:
                 cpu: 15m
-                memory: 64M
+                # Its index working set is well over the old 64M request, which
+                # made scheduling decisions on a number nothing like reality.
+                memory: 512Mi
               limits:
                 cpu: 2000m
-                memory: 2Gi
+                # Raised from 2Gi: it sat pinned at 2046Mi and the cgroup evicted
+                # page cache to stay under, so the memory-mapped index was read
+                # back from disk continuously -- ~1,900 major faults/s and a full
+                # core burned, with nothing in the logs and 13GiB free on the node.
+                memory: 4Gi
     service:
       syncthing:
         controller: syncthing


### PR DESCRIPTION
Syncthing sat at **2046Mi against a 2Gi limit** — 99.9% — so the cgroup evicted page cache to stay under it, and the memory-mapped index was read back from disk continuously.

Symptoms: **~1,900 major page faults/second and a full CPU core**, sustained for over a day, with **nothing in syncthing's logs** (zero lines in ten minutes) and initial scans long since complete.

## Why it presented as a node alert

`NodeMemoryMajorPagesFaults` fired on k3s-node3 while that node was at **47% memory with 13GiB free**. A cgroup reclaims regardless of what the node has spare, so a container pinned to its limit thrashes page cache in the middle of an idle node. The alert was accurate; it just described the symptom rather than the cause.

It also explains the timing. The node rebooted 08-25 15:07 and the faults began ~7 hours later — syncthing restarted cold and its index working set grew until it reached the ceiling, rather than hitting it at boot.

## Changes

- limit `2Gi` → `4Gi` — double rather than a nudge, since the working set clearly wants more than 2Gi and node3 has the room
- request `64M` → `512Mi` — the old value was nothing like reality and gave the scheduler a bad number

Identified by sampling per-process `majflt` on the node: syncthing 9,333 faults per 5s, Plex 5, everything else zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW