### PR TITLE
feat(litellm): add the ornith15-35b alias

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -83,6 +83,13 @@ data:
           model: openai/qwen38-27b
           api_base: http://${VLLM_DELL_HOST}:8001/v1
           api_key: sk-noauth
+      # Experimental. 35B total, 3B active, so it answers in the fast tier's
+      # latency class despite the size.
+      - model_name: ornith15-35b
+        litellm_params:
+          model: openai/ornith15-35b
+          api_base: http://${VLLM_GX10_HOST}:8002/v1
+          api_key: sk-noauth
       # --- future backends: add paid/free providers here, gated by sensitivity
       # tier. e.g. a cloud frontier model for hard/non-sensitive work:
       # - model_name: cloud-hard


### PR DESCRIPTION
Adds an explicit pin for `ornith15-35b` so it can be selected directly.

**Why it's interesting:** 35B total, **3B active** (256 experts, 8 per token). Generation tracks active parameters, so it should answer in the fast tier's latency class despite being larger than the current precise model — which is exactly the gap in the lineup, where the accurate model is also the slow one.

It also reports the same architecture family the engine already loads, so unlike other recent releases it needs no new engine support.

**Deliberately limited scope:**

- explicit pin only — not wired into `agent`, `agent-precise`, or any fallback chain
- served from the second inference host, not the one the agent aliases point at, so it cannot disturb them
- unproven: no evals, and the quality question needs the same real-work test that settled the last model comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW