### PR TITLE
feat(reloader): install stakater reloader

### DIFF
--- a/cluster/apps/kube-system/reloader/app/helm-release.yaml
+++ b/cluster/apps/kube-system/reloader/app/helm-release.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reloader
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: reloader
+      version: 2.2.16
+      sourceRef:
+        kind: HelmRepository
+        name: stakater-charts
+        namespace: flux-system
+  values:
+    reloader:
+      # Acts only on workloads carrying reloader.stakater.com/auto, which 14
+      # files across 12 apps already do -- those annotations have been inert
+      # until now and all take effect together.
+      watchGlobally: true
+      reloadStrategy: annotations
+      deployment:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+      podMonitor:
+        enabled: false

--- a/cluster/apps/kube-system/reloader/app/kustomization.yaml
+++ b/cluster/apps/kube-system/reloader/app/kustomization.yaml
@@ -3,5 +3,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kured/ks.yaml
-  - ./reloader/ks.yaml
+  - ./helm-release.yaml

--- a/cluster/apps/kube-system/reloader/ks.yaml
+++ b/cluster/apps/kube-system/reloader/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-reloader
+  namespace: flux-system
+spec:
+  path: ./cluster/apps/kube-system/reloader/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/cluster/base/flux-system/charts/helm/kustomization.yaml
+++ b/cluster/base/flux-system/charts/helm/kustomization.yaml
@@ -14,5 +14,6 @@ resources:
   - metallb-charts.yaml
   - nvidia-device-plugin-charts.yaml
   - prometheus-community-charts.yaml
+  - stakater-charts.yaml
   - traefik-charts.yaml
   - vllm-charts.yaml

--- a/cluster/base/flux-system/charts/helm/stakater-charts.yaml
+++ b/cluster/base/flux-system/charts/helm/stakater-charts.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: stakater-charts
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: https://stakater.github.io/stakater-charts


### PR DESCRIPTION
Config and secret changes have never restarted the workloads that consume them. Every app carrying `reloader.stakater.com/auto` has had an **inert** annotation, so a configmap edit needed a manual `rollout restart` — which has caught us out repeatedly, most recently on the litellm model list.

## Blast radius, deliberately accepted

**14 files across 12 apps** already carry the annotation, and **10 live deployments** have it right now — all dormant. Installing the controller activates all of them simultaneously, including stateful workloads where an unexpected restart is more than a blip.

That's the intended change, not an oversight. Flagging it because the diff looks like "add a controller" and behaves like "change restart semantics for ten workloads."

## Notes

- chart pinned to **2.2.16** (app `v1.4.21`) — my first guess at a version didn't exist
- every value key (`watchGlobally`, `reloadStrategy`, `deployment`, `podMonitor`) verified against that chart, since Helm silently ignores unknown keys rather than failing
- `reloadStrategy: annotations` rather than the default, so reloads are driven by the annotation rather than injected env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbYYoEVNy4UDrkbjKTr7KW