### PR TITLE
feat(ai): resolve vLLM aliases via VLLM_GX10_HOST

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -60,7 +60,7 @@ data:
           #    arrives inline in `content` alongside any tool_calls. Read
           #    tool_calls structurally; don't parse the prose.
           model: openai/nemotron35-lightning
-          api_base: http://${VLLM_DELL_HOST}:8000/v1
+          api_base: http://${VLLM_GX10_HOST}:8000/v1
           api_key: sk-noauth
       - model_name: agent-precise
         litellm_params:
@@ -69,19 +69,19 @@ data:
           # "agent" leaves it generic. Worth it when the argument matters more
           # than the round-trip.
           model: openai/qwen38-27b
-          api_base: http://${VLLM_DELL_HOST}:8001/v1
+          api_base: http://${VLLM_GX10_HOST}:8001/v1
           api_key: sk-noauth
       # Explicit pins, same backends -- for A/B work where you need to name the
       # model rather than the job. Mirrors the local/gemma4-12b pairing above.
       - model_name: nemotron35-lightning
         litellm_params:
           model: openai/nemotron35-lightning
-          api_base: http://${VLLM_DELL_HOST}:8000/v1
+          api_base: http://${VLLM_GX10_HOST}:8000/v1
           api_key: sk-noauth
       - model_name: qwen38-27b
         litellm_params:
           model: openai/qwen38-27b
-          api_base: http://${VLLM_DELL_HOST}:8001/v1
+          api_base: http://${VLLM_GX10_HOST}:8001/v1
           api_key: sk-noauth
       # Experimental. 35B total, 3B active, so it answers in the fast tier's
       # latency class despite the size.

--- a/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
+++ b/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
@@ -14,14 +14,11 @@ spec:
   scrapeInterval: 30s
   staticConfigs:
     - targets:
-        - "${VLLM_DELL_HOST}:8000"
-      labels: { job: vllm, box: gb10, served: nemotron35-lightning }
-    - targets:
-        - "${VLLM_DELL_HOST}:8001"
-      labels: { job: vllm, box: gb10, served: qwen38-27b }
-    - targets:
         - "${VLLM_GX10_HOST}:8000"
       labels: { job: vllm, box: gx10, served: nemotron35-lightning }
     - targets:
         - "${VLLM_GX10_HOST}:8001"
       labels: { job: vllm, box: gx10, served: qwen38-27b }
+    - targets:
+        - "${VLLM_GX10_HOST}:8002"
+      labels: { job: vllm, box: gx10, served: ornith15-35b }


### PR DESCRIPTION
## What

All four vLLM aliases (`agent`, `agent-precise`, `nemotron35-lightning`,
`qwen38-27b`) now resolve via `VLLM_GX10_HOST` instead of `VLLM_DELL_HOST`.

Verified before the change that the target serves the same models on the same
ports with the same native context windows:

```
:8000  nemotron35-lightning   max_model_len=1048576
:8001  qwen38-27b             max_model_len=262144
:8002  ornith15-35b           max_model_len=262144
```

Same served-model names, so no consumer or client-side context limit changes
are needed.

## Also

`vllm-metrics`: drop the two retired scrape targets, and add `ornith15-35b`,
which was serving without one.

`VLLM_DELL_HOST` is now unreferenced. Left defined in cluster-secrets rather
than removed, since editing it is a SOPS round-trip for no benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)