### PR TITLE
feat(ai): point the "local" alias at Gemma 4 26B-A4B

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -14,19 +14,25 @@ data:
       # api_base/model below. THIS is the whole reason LiteLLM goes in first.
       - model_name: local
         litellm_params:
-          # Back on the vLLM Gemma 4 12B (2026-06-19): the llama.cpp 26B-A4B was
-          # abandoned — Gemma-4 thinking on llama.cpp has open upstream termination
-          # bugs (peg-gemma4 parser loop ggml-org/llama.cpp#21375 + INT_MAX
-          # reasoning-budget default) that hang the model. Downstream (HA/GLaDOS,
-          # Vane) follow automatically — the whole point of the gateway.
-          model: openai/google/gemma-4-12B-it-qat-w4a16-ct
-          api_base: http://vllm-router-service.ai.svc.cluster.local:80/v1
+          # Gemma 4 26B-A4B on vLLM (2026-08-30), moved off the in-cluster
+          # backend while that accelerator is committed elsewhere. Serves the
+          # same 131072 window the 12B did, so client-side context limits carry
+          # over unchanged. Downstream (HA/GLaDOS, Vane) follows automatically —
+          # the whole point of the gateway.
+          #
+          # Earlier note, still true: a llama.cpp 26B-A4B was abandoned because
+          # Gemma-4 thinking there has open upstream termination bugs (peg-gemma4
+          # parser loop ggml-org/llama.cpp#21375 + INT_MAX reasoning-budget
+          # default) that hang the model. This is vLLM, not llama.cpp.
+          model: openai/gemma4-26b
+          api_base: http://${VLLM_DELL_HOST}:8003/v1
           api_key: sk-noauth
       # Explicit names so you can pin a specific backend regardless of what "local" is.
-      # NOTE: no gemma4-26b alias. The llamacpp backend behind it is parked at 0
-      # replicas, so the alias only ever returned a 500 -- and every consumer that
-      # lists models (OpenWebUI et al) still showed it as a choice. Re-add it here
-      # if llamacpp is ever brought back up.
+      - model_name: gemma4-26b
+        litellm_params:
+          model: openai/gemma4-26b
+          api_base: http://${VLLM_DELL_HOST}:8003/v1
+          api_key: sk-noauth
       - model_name: gemma4-12b
         litellm_params:
           # vLLM 12B — parked (its replicaCount is 0 while the 26B holds the GPU);

--- a/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
+++ b/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
@@ -13,6 +13,11 @@ spec:
   metricsPath: /metrics
   scrapeInterval: 30s
   staticConfigs:
+    # Backs the "local" alias, so it is scraped despite living on the host whose
+    # other services are transient.
+    - targets:
+        - "${VLLM_DELL_HOST}:8003"
+      labels: { job: vllm, box: gb10, served: gemma4-26b }
     - targets:
         - "${VLLM_GX10_HOST}:8000"
       labels: { job: vllm, box: gx10, served: nemotron35-lightning }


### PR DESCRIPTION
## What

`local` now resolves to the vLLM Gemma 4 26B-A4B on port 8003, instead of the
in-cluster backend that is unavailable while that accelerator is committed
elsewhere.

Verified serving before opening this:

```
Using 'MARLIN' NvFp4 MoE backend
Available KV cache memory: 17.26 GiB
Maximum concurrency for 131,072 tokens per request: 11.17x
health: healthy
```

Same 131072 window as the 12B it replaces, so client-side context limits carry
over unchanged and no downstream consumer needs touching.

## Also

- Adds an explicit `gemma4-26b` alias. The note explaining its absence described
  a parked llama.cpp backend, which is no longer the situation.
- Adds a scrape target for the endpoint, since it now backs `local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)