### PR TITLE
fix(paperless): set required PAPERLESS_SECRET_KEY

### DIFF
--- a/cluster/apps/paperless/paperless-ngx/app/helm-release.yaml
+++ b/cluster/apps/paperless/paperless-ngx/app/helm-release.yaml
@@ -43,6 +43,9 @@ spec:
               PAPERLESS_URL: "https://paperless.${SECRET_DOMAIN}"
               PAPERLESS_PORT: 8000
               PAPERLESS_OCR_LANGUAGE: eng
+            envFrom:
+              - secretRef:
+                  name: paperless
 
     service:
       paperless:

--- a/cluster/apps/paperless/paperless-ngx/app/kustomization.yaml
+++ b/cluster/apps/paperless/paperless-ngx/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helm-release.yaml
   - ingress-authentik.yaml
   - middleware-authentik.yaml
+  - secret.sops.yaml

--- a/cluster/apps/paperless/paperless-ngx/app/secret.sops.yaml
+++ b/cluster/apps/paperless/paperless-ngx/app/secret.sops.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: paperless
+    namespace: paperless
+stringData:
+    PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:xROGBdavaQOgUnwP5J6aOOPgAV/GcnRXNPc4Dg5j5fx1KCkzj68UZs6aqCJWKCash6SeQbBkKP3ba/KIvPa0Ow2zBWTVboeEzLLv75Um3qruc6RoXJ4=,iv:OcddU1oyYtwElFpE9AE+FnaZbTWPabYmHyCqHk2LyQg=,tag:VB3AKw8zKz5vGp/rj+w5+g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-09-03T18:13:45Z"
+    mac: ENC[AES256_GCM,data:Qm5h+O558m9vjJEvcgc+rOqoHewRtdnwsmxPsbZSNtvhzgGhJraMM1OJ/DgSYxvPsKNghvsSkP+J1o3HSe9JAKWYk3vmH7mkOOMxHZVa7g+vSf75nPlcHv661GrrofLjn2JpTzYWxfAd4UMwOtXh5jy4UOQl1xuyAWE8moNmPoU=,iv:iFV7wwTqvviSnMKcCZyNFv2pDhG4bnL7KwYyDg9+6LU=,tag:ofD4K5iv1JthdSt4gRoR2A==,type:str]
+    pgp:
+        - created_at: "2026-09-03T18:13:44Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA0dSZMvnEisuARAAgtEzzijdpDO+SocspPDS4MqefgbOsGIN0DB2L2bngMJs
+            knM9cbWSxm9DbtmOAXOqc256uO3zyyA0ByKdXYxqA+TgV+e+0ylHk4EFOJ7Oc5Go
+            R325KLIX9JwNG9W/fH/vH+0vQrxjFGLRUkWdbQf7/LAgwkFdQ3JqSe51Y/stz6j0
+            NzS13e9FRmOwNBVzxC5m3KiHQgDQBRu5aQMTaBobJJCbt9igI+/hsS0Unwhs2blO
+            2T9AexU0s4yhO7VKfuEJLQ3m4S+EF3Q+QYBmT0wUkyhT/xRi4lXnAPN5zB+9yxXj
+            nlEOv52LNLh7aRC9DlDrVyByO5QzREXYkdfJmsxZpys12PpXqUCmillGbsDFpOFe
+            1Xvd9vmTvFwTIhkhbpWjmJFt2t5TRuLVWTuqHaGlyIy99N4+/d+gHb2pipU2wPej
+            5vNBVboIlJ4J8D1qEeiLeQ+skpqazT2hDjD3FcpJ14wbRiWjpJjoQHtFH1TxN7cM
+            upp+NiSOh4Rh34OVIOzxvWrz0Sl7J1j3Tybof81EUFd/uW+Nwmx7ff8QAE2t29N4
+            UjZkoiTvn/cAvhYdkuhXeYuE8vjKozEOojXdNcAtHD7Ypp5acEDt5htz+9oUlQ4D
+            vfiXNPMQJAKz5Y/h8JCg2fqhYLvwwx0arTnt+lkCM5LuBmxhVq6SNH2JGBEXgOjS
+            XgG2YyNTgEFPn9prfF3s0fcW1NYqb4E2PLpk+VskYZvlQosPka1PbdSLse9EzBjU
+            rYmi0eJwqRDKErvKy6s4Vk9KTmjZ8b2BGjbIOWrHq3xFWCcPDhcoCqKVttkZqaY=
+            =jNey
+            -----END PGP MESSAGE-----
+          fp: 1DBC3ACFDB8B1DF2C44CDA23996024D3718273FA
+        - created_at: "2026-09-03T18:13:44Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAxbwxdi5IniFARAAvVeUIfsD7aEX43v/xHTeKZ7kCJaFSNrRqgRbkRLIdBUw
+            UBmGWaeTTWQ/LpP9Psox+KbU4wCdc/WI0b/2VxMU0rumpAdqye+8WTbXiGtEe/Wo
+            qKzzuRAEnj13W+ngUdCYllSWcuX99L1fsgvaK+EnnafAVohS7FGaMfo62MOBd2a3
+            7KabUZ46n65/HtDXcUD+wVoOds73LkbPy/e47HjdK8FaVAXv7kSnaCuKD5HQFJ9X
+            GcFURrEQP1oZyWTmYgqZwH4dBZqzmbjL6xLVQ1cvtHEHi7/VK/w2gQ7F9uYMbOum
+            xQXdtSd0aFXFVh7NBd8MEg703HpJ1Dkoauvb9XfuXLb3y2zIm5M1oHnSuviCFQBS
+            0owy2lqEKHTBBGDue0oA9Y5hwY70RWqKyOkDA9TCJsQcdBKiZpGRVzYlBtr6qyV2
+            8ob5qPO13wcv3KPLb2pPdGckfFFu5n7bRmkbf2Yg8fEtlibz9U+b4cIQC0r5cPTX
+            NTXACCZNUaeGSm98Sy64F5X9B1fZw4ewWFR6LYtAks//o6OyD7h/hMCmCLS3x22b
+            MK9jEZhPM4Uv5OWfuSIpkmZ5b4hWnBUz9oFe/zAM2MKXzmTeZbZI2Wu8zEpPaTqO
+            7ScXDwcCsQkZxQMBTxGQZpOxunTpBNXN7i6Gn8ikT27yAQcTMJGdSjbFjRbVBcXS
+            XgFEuaHeQYXaaj12wF0DB2amlPTcHHSASGJaLQqN5bO4ljJY3M13pya9E4pn3Xnk
+            alSA37beBinB4EuJEzDFhSP5379ZtBI0+AV+M6YflP++Rs5NV87PBOQAEIvqh7Q=
+            =Y+JS
+            -----END PGP MESSAGE-----
+          fp: D9F3AF2D9762D61A974DCD3E7B318B162A7DEBC9
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1


### PR DESCRIPTION
## Summary
- paperless-ngx v3.1.2 (merged in #1738) requires an explicit `PAPERLESS_SECRET_KEY` and crash-loops without one
- Adds a SOPS-encrypted secret and wires it in via `envFrom`, matching the pattern used by searxng/others

## Test plan
- [x] sops encryption verified by pre-commit hook
- [ ] Merge and confirm paperless pod comes up healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dkBXwAyAoozWoWuC1RQM5