### PR TITLE
feat(litellm): repoint local/gemma4-26b from VLLM_DELL_HOST to VLLM_GX10_HOST

### DIFF
--- a/cluster/apps/ai/litellm/app/configmap.yaml
+++ b/cluster/apps/ai/litellm/app/configmap.yaml
@@ -20,18 +20,23 @@ data:
           # over unchanged. Downstream (HA/GLaDOS, Vane) follows automatically —
           # the whole point of the gateway.
           #
+          # Moved again 2026-09-06 from VLLM_DELL_HOST to VLLM_GX10_HOST: same
+          # model/config, different accelerator in the pair. Moving this alias
+          # to different hardware is always a cluster-secrets var change, not a
+          # config change.
+          #
           # Earlier note, still true: a llama.cpp 26B-A4B was abandoned because
           # Gemma-4 thinking there has open upstream termination bugs (peg-gemma4
           # parser loop ggml-org/llama.cpp#21375 + INT_MAX reasoning-budget
           # default) that hang the model. This is vLLM, not llama.cpp.
           model: openai/gemma4-26b
-          api_base: http://${VLLM_DELL_HOST}:8003/v1
+          api_base: http://${VLLM_GX10_HOST}:8003/v1
           api_key: sk-noauth
       # Explicit names so you can pin a specific backend regardless of what "local" is.
       - model_name: gemma4-26b
         litellm_params:
           model: openai/gemma4-26b
-          api_base: http://${VLLM_DELL_HOST}:8003/v1
+          api_base: http://${VLLM_GX10_HOST}:8003/v1
           api_key: sk-noauth
       - model_name: gemma4-12b
         litellm_params:

--- a/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
+++ b/cluster/apps/ai/vllm-metrics/app/scrapeconfig.yaml
@@ -13,11 +13,6 @@ spec:
   metricsPath: /metrics
   scrapeInterval: 30s
   staticConfigs:
-    # Backs the "local" alias, so it is scraped despite living on the host whose
-    # other services are transient.
-    - targets:
-        - "${VLLM_DELL_HOST}:8003"
-      labels: { job: vllm, box: gb10, served: gemma4-26b }
     - targets:
         - "${VLLM_GX10_HOST}:8000"
       labels: { job: vllm, box: gx10, served: nemotron35-lightning }
@@ -27,3 +22,8 @@ spec:
     - targets:
         - "${VLLM_GX10_HOST}:8002"
       labels: { job: vllm, box: gx10, served: ornith15-35b }
+    # Backs the "local" alias, so it is scraped despite being last in the file.
+    # Moved from gb10 2026-09-06 -- see the configmap comment.
+    - targets:
+        - "${VLLM_GX10_HOST}:8003"
+      labels: { job: vllm, box: gx10, served: gemma4-26b }


### PR DESCRIPTION
## Summary
- Moves the `local`/`gemma4-26b` LiteLLM aliases and their Prometheus scrape target from `VLLM_DELL_HOST` to `VLLM_GX10_HOST` -- same model/config, different accelerator
- No secrets/vars added or removed (both env vars already exist in cluster-secrets)

## Test plan
- [x] Lint hooks passed locally (yamllint, prettier, kubeconform, kustomize build smoke)
- [ ] After merge + Flux reconcile: `kubectl -n ai rollout restart deploy/litellm` (reloader annotation is inert, confirmed elsewhere in this repo)
- [ ] Smoke-test a completion through `local` and confirm it lands on the gx10 backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPwgYZnwcDVddotr3anqa9